### PR TITLE
refactor send() to accept send(req, path) as well as send(path)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -17,7 +17,7 @@ var http = require('http');
 var send = require('send');
 
 var app = http.createServer(function(req, res){
-  send(req.url).pipe(res);
+  send(req, req.url).pipe(res);
 });
 ```
 

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -7,7 +7,7 @@ var send = require('..')
   , http = require('http');
 
 http.createServer(function(req, res){
-  send(req.url)
+  send(req, req.url)
   .from(__dirname + '/public')
   .maxage(60000)
   .pipe(res);

--- a/lib/send.js
+++ b/lib/send.js
@@ -29,15 +29,20 @@ exports = module.exports = send;
 exports.mime = mime;
 
 /**
- * Return a `SendStream` for `path`.
+ * Return a `SendStream` for `path` or `req` or both.
  *
- * @param {String} path
+ * @param {ServerRequest} req
  * @return {SendStream}
  * @api public
  */
 
-function send(path) {
-  return new SendStream(path);
+function send(req, path) {
+  if('string' == typeof req) {
+    path = req;
+    req = undefined;
+  }
+
+  return new SendStream(req, path);
 }
 
 /**
@@ -54,9 +59,9 @@ function send(path) {
  * @api private
  */
 
-function SendStream(path) {
-  var self = this;
+function SendStream(req, path) {
   this.path = path;
+  this.req = req;
   this.maxage(0);
   this.hidden(false);
   this.index('index.html');
@@ -184,6 +189,7 @@ SendStream.prototype.hasLeadingDot = function(){
  */
 
 SendStream.prototype.isConditionalGET = function(){
+  if(!this.req) return false;
   return this.req.headers['if-none-match']
     || this.req.headers['if-modified-since'];
 };
@@ -286,7 +292,6 @@ SendStream.prototype.pipe = function(res){
 
   // references
   this.res = res;
-  this.req = res.socket.parser.incoming; // TODO: wtf?
 
   // invalid request uri
   path = utils.decode(path);
@@ -328,11 +333,12 @@ SendStream.prototype.pipe = function(res){
  */
 
 SendStream.prototype.send = function(path, stat){
-  var options = {};
-  var len = stat.size;
-  var res = this.res;
-  var req = this.req;
-  var ranges = req.headers.range;
+  var options = {}
+    , len = stat.size
+    , res = this.res
+    , req = this.req
+    , ranges = req && req.headers.range
+    , method = req && req.method || 'GET';
 
   // set header fields
   this.setHeader(stat);
@@ -378,7 +384,7 @@ SendStream.prototype.send = function(path, stat){
   res.setHeader('Content-Length', len);
 
   // HEAD support
-  if ('HEAD' == req.method) return res.end();
+  if ('HEAD' == method) return res.end();
 
   this.stream(path, options);
 };
@@ -403,7 +409,7 @@ SendStream.prototype.stream = function(path, options){
   stream.pipe(res);
 
   // socket closed, done with the fd
-  req.on('close', stream.destroy.bind(stream));
+  if(req) req.on('close', stream.destroy.bind(stream));
 
   // error handling code-smell
   stream.on('error', function(err){

--- a/test/send.js
+++ b/test/send.js
@@ -19,7 +19,7 @@ var app = http.createServer(function(req, res){
     res.end('Redirecting to ' + req.url + '/');
   }
 
-  send('test/fixtures' + req.url)
+  send(req, 'test/fixtures' + req.url)
   .on('error', error)
   .on('directory', redirect)
   .pipe(res);


### PR DESCRIPTION
- added `req` as an optional param to `send(req, path)`
- should be backwards compatible, but opts out of certain request based security things (it just ignores them if you don't pass req)

There was a pretty nasty dependency here:

https://github.com/visionmedia/send/blob/master/lib/send.js#L289

I thought factoring out req entirely would make this a bit more predictable... although I can see not wanting to expose req.

This took about 5 minutes, so feel free to toss it. I wouldn't merge this even though tests are passing... this is more of a... 'how bout this api'.

The big thing to note before merging is I changed the main test macro to use `send(req, path)`. Thats really dangerous, but if you're for this api, I can write up some decent tests.
