### PR TITLE
content-length is incorrect when requested range.end is larger than the actual content-length

### DIFF
--- a/lib/send.js
+++ b/lib/send.js
@@ -362,7 +362,7 @@ SendStream.prototype.send = function(path, stat){
     // valid (syntactically invalid ranges are treated as a regular response)
     if (-2 != ranges) {
       options.start = ranges[0].start;
-      options.end = ranges[0].end;
+      options.end = Math.min(ranges[0].end, stat.size - 1);
 
       // Content-Range
       len = options.end - options.start + 1;


### PR DESCRIPTION
Fixed by taking the minimum of requested range.end and actual content-length (-1)
