### PR TITLE
Allow custom-set "Accept-Ranges" header

### DIFF
--- a/lib/send.js
+++ b/lib/send.js
@@ -454,7 +454,7 @@ SendStream.prototype.type = function(path){
 
 SendStream.prototype.setHeader = function(stat){
   var res = this.res;
-  res.setHeader('Accept-Ranges', 'bytes');
+  if (!res.getHeader('Accept-Ranges')) res.setHeader('Accept-Ranges', 'bytes');
   if (!res.getHeader('ETag')) res.setHeader('ETag', utils.etag(stat));
   if (!res.getHeader('Date')) res.setHeader('Date', new Date().toUTCString());
   if (!res.getHeader('Cache-Control')) res.setHeader('Cache-Control', 'public, max-age=' + (this._maxage / 1000));


### PR DESCRIPTION
Allow the main application to deny range requests by setting response header "Accept-Ranges" to "none". This also enables a workaround for connect bug https://github.com/senchalabs/connect/issues/599 which affects PDF downloads by the Adobe PDF Plugin.
