### PR TITLE
add options parameter to send() that is passed to fs.createReadStream()

### DIFF
--- a/lib/send.js
+++ b/lib/send.js
@@ -33,12 +33,13 @@ exports.mime = mime;
  *
  * @param {Request} req
  * @param {String} path
+ * @param {Object} options
  * @return {SendStream}
  * @api public
  */
 
-function send(req, path) {
-  return new SendStream(req, path);
+function send(req, path, options) {
+  return new SendStream(req, path, options);
 }
 
 /**
@@ -53,13 +54,15 @@ function send(req, path) {
  *
  * @param {Request} req
  * @param {String} path
+ * @param {Object} options
  * @api private
  */
 
-function SendStream(req, path) {
+function SendStream(req, path, options) {
   var self = this;
   this.req = req;
   this.path = path;
+  this.options = options || {};
   this.maxage(0);
   this.hidden(false);
   this.index('index.html');
@@ -330,11 +333,12 @@ SendStream.prototype.pipe = function(res){
  */
 
 SendStream.prototype.send = function(path, stat){
-  var options = {};
+  var options = this.options;
   var len = stat.size;
   var res = this.res;
   var req = this.req;
   var ranges = req.headers.range;
+  var offset = options.start || 0;
 
   // set header fields
   this.setHeader(stat);
@@ -349,6 +353,13 @@ SendStream.prototype.send = function(path, stat){
     return this.notModified();
   }
 
+  // adjust len to start/end options
+  len = Math.max(0, len-offset);
+  if (options.end !== undefined) {
+    var bytes = options.end - offset + 1;
+    if (len > bytes) len = bytes;
+  }
+
   // Range support
   if (ranges) {
     ranges = parseRange(len, ranges);
@@ -361,18 +372,18 @@ SendStream.prototype.send = function(path, stat){
 
     // valid (syntactically invalid ranges are treated as a regular response)
     if (-2 != ranges) {
-      options.start = ranges[0].start;
-      options.end = ranges[0].end;
+      options.start = offset + ranges[0].start;
+      options.end = offset + ranges[0].end;
 
       // Content-Range
-      len = options.end - options.start + 1;
       res.statusCode = 206;
       res.setHeader('Content-Range', 'bytes '
-        + options.start
+        + ranges[0].start
         + '-'
-        + options.end
+        + ranges[0].end
         + '/'
-        + stat.size);
+        + len);
+      len = options.end - options.start + 1;
     }
   }
 

--- a/test/send.js
+++ b/test/send.js
@@ -290,6 +290,32 @@ describe('send(file).pipe(res)', function(){
       })
     })
   })
+
+  describe('when "options" is specified', function(){
+    it('should support start/end', function(done){
+      var app = http.createServer(function(req, res){
+        var i = parseInt(req.url.slice(1));
+        send(req, 'test/fixtures/nums', { start:i*3, end:i*3+2 }).pipe(res);
+      });
+
+      request(app)
+      .get('/1')
+      .expect('456', done);
+    })
+
+    it('should support start/end with Range request', function(done){
+      var app = http.createServer(function(req, res){
+        var i = parseInt(req.url.slice(1));
+        send(req, 'test/fixtures/nums', { start:i*3, end:i*3+2 }).pipe(res);
+      });
+
+      request(app)
+      .get('/0')
+      .set('Range', 'bytes=-2')
+      .expect('23')
+      .end(done);
+    })
+  })
 })
 
 describe('send(file, options)', function(){


### PR DESCRIPTION
This enables my use case where I need to serve only part of a file, determined server-side, and not via the range header.
