### PR TITLE
emit a file event

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -57,6 +57,7 @@ var app = http.createServer(function(req, res){
 
   - `error` an error occurred `(err)`
   - `directory` a directory was requested
+  - `file` a file was requested `(path, stat)`
   - `stream` file streaming has started `(stream)`
   - `end` streaming has completed
 

--- a/lib/send.js
+++ b/lib/send.js
@@ -319,6 +319,7 @@ SendStream.prototype.pipe = function(res){
   fs.stat(path, function(err, stat){
     if (err) return self.onStatError(err);
     if (stat.isDirectory()) return self.redirect(self.path);
+    self.emit('file', path, stat);
     self.send(path, stat);
   });
 


### PR DESCRIPTION
I'm writing a drop-in replacement for `connect.static` that watches the served files and notifies the client via server-sent events. This requires a hook where both the requested URL as well as the resolved file path is known. The existing `stream` event would do, but of course it isn't fired in case of conditional GETs. Adding an additional `file` event was the simplest solution I could think of.
