### PR TITLE
fd leak in send

### DIFF
--- a/lib/send.js
+++ b/lib/send.js
@@ -318,6 +318,10 @@ SendStream.prototype.pipe = function(res){
   debug('stat "%s"', path);
   fs.stat(path, function(err, stat){
     if (err) return self.onStatError(err);
+    if (!(self.req.socket && self.req.socket._handle)) {
+      self.emit('error', new Error("Connection closed"));
+      return;
+    }
     if (stat.isDirectory()) return self.redirect(self.path);
     self.emit('file', path, stat);
     self.send(path, stat);


### PR DESCRIPTION
If request was disconnected before the stat() callback was called, we
will never get the 'close' or 'error' event and the file descriptor will
stay open forever
Note that this fix:
https://github.com/joyent/node/issues/5770
https://github.com/visionmedia/express/issues/1554
