### PR TITLE
Allow to disable etag generation and implement optional negotiation

### DIFF
--- a/lib/send.js
+++ b/lib/send.js
@@ -171,7 +171,7 @@ SendStream.prototype.error = function(status, err){
   var msg = http.STATUS_CODES[status];
   err = err || new Error(msg);
   err.status = status;
-  if (this.listeners('error').length) return this.emit('error', err);
+  if (this.listeners('error').length) this.emit('error', err);
   res.statusCode = err.status;
   res.end(msg);
 };


### PR DESCRIPTION
- This allows to disable etag generation (still enabled by default)
- Allows to externalize content negotiation easily with a module like 
  https://github.com/federomero/negotiator (disabled by default)
