### PR TITLE
Ensure path is a string so normalize can function properly

### DIFF
--- a/lib/send.js
+++ b/lib/send.js
@@ -113,7 +113,7 @@ SendStream.prototype.index = function(path){
 
 SendStream.prototype.root = 
 SendStream.prototype.from = function(path){
-  this._root = normalize(path);
+  this._root = normalize(path.toString());
   return this;
 };
 


### PR DESCRIPTION
On my desktop (ArchLinux), I get a `TypeError: Object /path/to/file has no method 'charAt'`. For some reason, `path` is being passed in as an `Object` in this case. This change simply ensures a string is used by calling `toString()` so normalize wont freak out.

Interestingly, my Macbook Pro has no issues.
