### PR TITLE
Ignore stream errors after req close

### DIFF
--- a/lib/send.js
+++ b/lib/send.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -521,10 +520,15 @@ SendStream.prototype.stream = function(path, options){
   stream.pipe(res);
 
   // socket closed, done with the fd
-  req.on('close', stream.destroy.bind(stream));
+  var reqWasClosed;
+  req.on('close', function(){
+    stream.destroy(stream);
+    reqWasClosed = true;
+  });
 
   // error handling code-smell
   stream.on('error', function(err){
+    if(reqWasClosed) return;
     // no hope in responding
     if (res._header) {
       console.error(err.stack);


### PR DESCRIPTION
When serving video files and seeking on video, browser frequently cancels requests. And I have seen situations when request is closed in the middle of read.
