### PR TITLE
enable providing custom fs-api

### DIFF
--- a/lib/send.js
+++ b/lib/send.js
@@ -69,6 +69,7 @@ function SendStream(req, path, options) {
   this.etag(('etag' in options) ? options.etag : true);
   this.maxage(options.maxage);
   this.hidden(options.hidden);
+  this.fs(options.fs);
   this.index(('index' in options) ? options.index : 'index.html');
   if (options.root || options.from) this.root(options.root || options.from);
 }
@@ -106,6 +107,22 @@ SendStream.prototype.hidden = function(val){
   val = Boolean(val);
   debug('hidden %s', val);
   this._hidden = val;
+  return this;
+};
+
+/**
+ * Provide a custom filesystem-api,
+ * default is `require('fs')`.
+ *
+ * @param {Object} filesystem-api
+ * @return {SendStream}
+ * @api public
+ */
+
+SendStream.prototype.fs = function(val){
+  debug('fs %s', val ? 'custom' : 'core');
+  val = val || fs;
+  this._fs = val;
   return this;
 };
 
@@ -374,7 +391,7 @@ SendStream.prototype.pipe = function(res){
   }
 
   debug('stat "%s"', path);
-  fs.stat(path, function(err, stat){
+  this._fs.stat(path, function(err, stat){
     if (err) return self.onStatError(err);
     if (stat.isDirectory()) return self.redirect(self.path);
     self.emit('file', path, stat);
@@ -488,7 +505,7 @@ SendStream.prototype.sendIndex = function sendIndex(path){
     var p = path + self._index[i];
 
     debug('stat "%s"', p);
-    fs.stat(p, function(err, stat){
+    self._fs.stat(p, function(err, stat){
       if (err) return next(err);
       if (stat.isDirectory()) return self.redirect(self.path);
       self.emit('file', p, stat);
@@ -516,7 +533,7 @@ SendStream.prototype.stream = function(path, options){
   var req = this.req;
 
   // pipe
-  var stream = fs.createReadStream(path, options);
+  var stream = this._fs.createReadStream(path, options);
   this.emit('stream', stream);
   stream.pipe(res);
 


### PR DESCRIPTION
this would make the following possible:

``` javascript
var db = require('level')('/tmp/file.db')
var fs = require('level-filesystem')(db)
var send = require('send')
var http = require('http')
http.createServer(function(req, res){
  send(req, req.url, {fs:fs}).pipe(res)
}).listen(1337)
```
