### PR TITLE
Round max-age to nearest second

### DIFF
--- a/lib/send.js
+++ b/lib/send.js
@@ -581,7 +581,7 @@ SendStream.prototype.setHeader = function setHeader(path, stat){
   var res = this.res;
   if (!res.getHeader('Accept-Ranges')) res.setHeader('Accept-Ranges', 'bytes');
   if (!res.getHeader('Date')) res.setHeader('Date', new Date().toUTCString());
-  if (!res.getHeader('Cache-Control')) res.setHeader('Cache-Control', 'public, max-age=' + (this._maxage / 1000));
+  if (!res.getHeader('Cache-Control')) res.setHeader('Cache-Control', 'public, max-age=' + Math.round(this._maxage / 1000));
   if (!res.getHeader('Last-Modified')) res.setHeader('Last-Modified', stat.mtime.toUTCString());
 
   if (this._etag && !res.getHeader('ETag')) {


### PR DESCRIPTION
The [HTTP 1.1 spec](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html) doesn't explicitly say that these must be integers, but many other fields are supposed to be.

Not sure if this should be merged because the spec is unclear, but this might be worth discussing.
