### PR TITLE
Emit an error when the request is aborted.

### DIFF
--- a/lib/send.js
+++ b/lib/send.js
@@ -647,10 +647,14 @@ SendStream.prototype.stream = function(path, options){
   // pipe
   var stream = fs.createReadStream(path, options);
   this.emit('stream', stream);
+  stream.on('end', function () { finished = true; });
   stream.pipe(res);
 
-  // response finished, done with the fd
-  onFinished(res, function onfinished(){
+  // response finished
+  onFinished(res, function onfinished(err){
+    if (!finished) {
+      self.emit('error', err || new Error('Request was aborted'));
+    }
     finished = true;
     destroy(stream);
   });


### PR DESCRIPTION
I think it send should emit an error if the request is aborted. Handling aborted requests outside of send is painful.
