### PR TITLE
Insecure comparison

### DIFF
--- a/index.js
+++ b/index.js
@@ -415,7 +415,7 @@ SendStream.prototype.pipe = function(res){
     root = normalize(root)
 
     // malicious path
-    if (path.substr(0, root.length) !== root) {
+    if (path === root || path.substr(0, root.length + 1) !== root + sep) {
       debug('malicious path "%s"', path)
       return this.error(403)
     }


### PR DESCRIPTION
Without that fix, a path `/my-secret` is consedered fine for the root `/my`.

Maybe the issue is autofixed by the next `parts` assignment? Not sure exactly if the vulnerability exists, but the comparison is insecure.
