### PR TITLE
Allow to add fs in options

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,6 +80,7 @@ function SendStream(req, path, options) {
   this.req = req;
   this.path = path;
   this.options = options;
+  this.fs = options.fs || fs;
 
   this._etag = options.etag !== undefined
     ? Boolean(options.etag)
@@ -572,7 +573,7 @@ SendStream.prototype.sendFile = function sendFile(path) {
   var self = this
 
   debug('stat "%s"', path);
-  fs.stat(path, function onstat(err, stat) {
+  self.fs.stat(path, function onstat(err, stat) {
     if (err && err.code === 'ENOENT'
       && !extname(path)
       && path[path.length - 1] !== sep) {
@@ -595,7 +596,7 @@ SendStream.prototype.sendFile = function sendFile(path) {
     var p = path + '.' + self._extensions[i++]
 
     debug('stat "%s"', p)
-    fs.stat(p, function (err, stat) {
+    self.fs.stat(p, function (err, stat) {
       if (err) return next(err)
       if (stat.isDirectory()) return next()
       self.emit('file', p, stat)
@@ -623,7 +624,7 @@ SendStream.prototype.sendIndex = function sendIndex(path){
     var p = join(path, self._index[i]);
 
     debug('stat "%s"', p);
-    fs.stat(p, function(err, stat){
+    self.fs.stat(p, function(err, stat){
       if (err) return next(err);
       if (stat.isDirectory()) return next();
       self.emit('file', p, stat);
@@ -650,7 +651,7 @@ SendStream.prototype.stream = function(path, options){
   var req = this.req;
 
   // pipe
-  var stream = fs.createReadStream(path, options);
+  var stream = self.fs.createReadStream(path, options);
   this.emit('stream', stream);
   stream.pipe(res);
 


### PR DESCRIPTION
Hi,

I had a need to implement my own virtual file system inside Node.JS to serve static file.
I have been able to do so, without being too invasive, by overriding fs.

My use case was to serve files contained inside a zip, but this allow lots of uses cases, such as serving files contained is a database.

Would be great if you also find it usefull.
