### PR TITLE
tests: add test for empty files

### DIFF
--- a/index.js
+++ b/index.js
@@ -567,6 +567,10 @@ SendStream.prototype.send = function(path, stat){
   opts.start = offset
   opts.end = offset + len - 1
 
+  if (opts.end === -1) {
+    opts.end = 0;
+  }
+
   // content-length
   res.setHeader('Content-Length', len);
 

--- a/test/send.js
+++ b/test/send.js
@@ -796,6 +796,14 @@ describe('send(file, options)', function(){
     })
   })
 
+  describe('empty files', function () {
+    it('should support empty files', function (done) {
+      request(createServer({root: fixtures}))
+          .get('/empty')
+          .expect(200, '', done)
+    })
+  })
+
   describe('from', function(){
     it('should set with deprecated from', function(done){
       var app = http.createServer(function(req, res){


### PR DESCRIPTION
RE: https://github.com/expressjs/serve-static/issues/29

Because of https://github.com/pillarjs/send/commit/5c0afa976a32d3c7d3838f85aa60bda4b170b3e6#diff-168726dbe96b3ce427e7fedce31bb0bcL570

The call to `fs.createReadStream(path, options);` now inherits options that may not be desired: 

https://github.com/pillarjs/send/blob/master/index.js#L668

Whilst i'm sure you'll fix it in a different way, this PR at least has tracked the bug down and provided a test case for it.

Thanks. 