### PR TITLE
deps: remove debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,14 +112,6 @@ such as Varnish for this, or those fancy things called CDNs. If your
 application is small enough that it would benefit from single-node memory
 caching, it's small enough that it does not need caching at all ;).
 
-## Debugging
-
-To enable `debug()` instrumentation output export __DEBUG__:
-
-```
-$ DEBUG=send node app
-```
-
 ## Running tests
 
 ```

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "server"
   ],
   "dependencies": {
-    "debug": "~2.1.1",
     "depd": "~1.0.0",
     "destroy": "1.0.3",
     "escape-html": "1.0.1",


### PR DESCRIPTION
It is extraneous dependency if you do not need debug. Even for debug, it would be better to have events system instead of using `debug` package.

Express uses the `debug` package ([ref](http://expressjs.com/guide/debugging.html)) for this purpose, but this package is not express-only package.