### PR TITLE
Add `fs` option for using other filesystem implementations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,28 @@ Serve files relative to `path`.
 
 Use a filesystem other than the node-js built-in `fs` module. It must support the following methods:
 
- * stat(path)
- * createReadStream(path)
+ * stat(path, callback)
+ * createReadStream(path, options)
+
+The resulting stat object from `stat` must (at least) look like:
+
+```javascript
+{
+    mtime: Date,
+    ctime: Date,
+    ino: Number,
+    size: Number
+}
+```
+
+The resulting readable stream must (at least) support the options:
+
+```javascript
+{
+    start: Number,
+    end: Number
+}
+```
 
 ### Events
 

--- a/README.md
+++ b/README.md
@@ -87,28 +87,47 @@ Serve files relative to `path`.
 
 Use a filesystem other than the node-js built-in `fs` module. It must support the following methods:
 
- * stat(path, callback)
- * createReadStream(path, options)
+ * `stat(path, callback)`
+ * `createReadStream(path, options)``
 
-The resulting stat object from `stat` must (at least) look like:
+The `callback` given to `stat` has two parameters: `(err, result)`.
 
-```javascript
-{
-    mtime: Date,
-    ctime: Date,
-    ino: Number,
-    size: Number
-}
-```
-
-The resulting readable stream must (at least) support the options:
+`err`: The `err` parameter should be an object with a `code` property containing error information.
 
 ```javascript
 {
-    start: Number,
-    end: Number
+    code: String // Error code.
 }
 ```
+
+The following codes are respected: 'ENAMETOOLONG', 'ENOENT', and 'ENOTDIR'. Descriptions of these errors can be found [here](https://github.com/rvagg/node-errno/blob/master/errno.js).
+
+`result`: The `result` stat object from `stat` must (at least) look like:
+
+```javascript
+{
+    mtime: Date, // Modification date
+    ctime: Date, // Creation date
+    ino: Number, // Unique id
+    size: Number, // Length of object, in bytes
+    isDirectory: Function // Returns true if object is directory
+}
+```
+
+NOTE: The `ino` property represents the file-system inode, which is unique to the given _filesystem_ meaning that for `fs` where it's possible to access multiple mounted filesystems `ino` is not unique, but for any virtual driver it would be reasonable to ensure that `ino` numbers are.
+
+For complete details about these (and other) properties on the `stat` object be sure to see the [documentation](https://nodejs.org/api/fs.html#fs_class_fs_stats).
+
+The `createReadStream` method must (at least) support the options:
+
+```javascript
+{
+    start: Number, // Start offset of data to read
+    end: Number // End offset of data to read
+}
+```
+
+For complete details about these (and other) options of the `createReadStream` method be sure to see the [documentation](https://nodejs.org/api/fs.html#fs_fs_createreadstream_path_options).
 
 ### Events
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ This can also be a string accepted by the
 
 Serve files relative to `path`.
 
+##### fs
+
+Use a filesystem other than the node-js built-in `fs` module. It must support the following methods:
+
+ * stat(path)
+ * createReadStream(path)
+
 ### Events
 
 The `SendStream` is an event emitter and will emit the following events:
@@ -177,7 +184,7 @@ var app = http.createServer(function(req, res){
 }).listen(3000);
 ```
 
-## License 
+## License
 
 [MIT](LICENSE)
 

--- a/index.js
+++ b/index.js
@@ -95,6 +95,10 @@ function SendStream(req, path, options) {
     ? opts.dotfiles
     : 'ignore'
 
+  this._fs = opts.fs !== undefined
+    ? opts.fs
+    : fs;
+
   if (this._dotfiles !== 'ignore' && this._dotfiles !== 'allow' && this._dotfiles !== 'deny') {
     throw new TypeError('dotfiles option must be "allow", "deny", or "ignore"')
   }
@@ -611,7 +615,7 @@ SendStream.prototype.sendFile = function sendFile(path) {
   var self = this
 
   debug('stat "%s"', path);
-  fs.stat(path, function onstat(err, stat) {
+  self._fs.stat(path, function onstat(err, stat) {
     if (err && err.code === 'ENOENT'
       && !extname(path)
       && path[path.length - 1] !== sep) {
@@ -634,7 +638,7 @@ SendStream.prototype.sendFile = function sendFile(path) {
     var p = path + '.' + self._extensions[i++]
 
     debug('stat "%s"', p)
-    fs.stat(p, function (err, stat) {
+    self._fs.stat(p, function (err, stat) {
       if (err) return next(err)
       if (stat.isDirectory()) return next()
       self.emit('file', p, stat)
@@ -662,7 +666,7 @@ SendStream.prototype.sendIndex = function sendIndex(path){
     var p = join(path, self._index[i]);
 
     debug('stat "%s"', p);
-    fs.stat(p, function(err, stat){
+    self._fs.stat(p, function(err, stat){
       if (err) return next(err);
       if (stat.isDirectory()) return next();
       self.emit('file', p, stat);
@@ -689,7 +693,7 @@ SendStream.prototype.stream = function(path, options){
   var req = this.req;
 
   // pipe
-  var stream = fs.createReadStream(path, options);
+  var stream = this._fs.createReadStream(path, options);
   this.emit('stream', stream);
   stream.pipe(res);
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "after": "0.8.1",
     "istanbul": "0.3.9",
     "mocha": "2.2.5",
-    "supertest": "1.0.1"
+    "supertest": "1.0.1",
+    "readable-stream": "2.0.1"
   },
   "files": [
     "HISTORY.md",

--- a/test/send.js
+++ b/test/send.js
@@ -7,7 +7,7 @@ var fs = require('fs');
 var http = require('http');
 var path = require('path');
 var request = require('supertest');
-var stream = require('stream');
+var ReadableStream = require('readable-stream');
 var send = require('..')
 
 // test server
@@ -1298,7 +1298,7 @@ describe('send(file, options)', function(){
               },
               createReadStream: function() {
                   createReadStreamCalled = true
-                  var bam = stream.Readable()
+                  var bam = new ReadableStream()
                   bam.push(res)
                   bam.push(null)
                   return bam;

--- a/test/send.js
+++ b/test/send.js
@@ -7,6 +7,7 @@ var fs = require('fs');
 var http = require('http');
 var path = require('path');
 var request = require('supertest');
+var stream = require('stream');
 var send = require('..')
 
 // test server
@@ -410,14 +411,14 @@ describe('send(file).pipe(res)', function(){
       .set('Range', 'bytes=0-4')
       .expect(206, '12345', done);
     })
-    
+
     it('should be inclusive', function(done){
       request(app)
       .get('/nums')
       .set('Range', 'bytes=0-0')
       .expect(206, '1', done);
     })
-    
+
     it('should set Content-Range', function(done){
       request(app)
       .get('/nums')
@@ -432,7 +433,7 @@ describe('send(file).pipe(res)', function(){
       .set('Range', 'bytes=-3')
       .expect(206, '789', done);
     })
-    
+
     it('should support n-', function(done){
       request(app)
       .get('/nums')
@@ -1063,7 +1064,7 @@ describe('send(file, options)', function(){
         send(req, 'test/fixtures/name.txt', {maxAge: Infinity})
         .pipe(res);
       });
-      
+
       request(app)
       .get('/name.txt')
       .expect('Cache-Control', 'public, max-age=31536000', done)
@@ -1275,6 +1276,48 @@ describe('send(file, options)', function(){
         .expect(200, '...', done);
       })
     })
+  })
+
+  describe('fs', function() {
+      it('should invoke correct fs methods', function(done) {
+          var statCalled = false
+          var createReadStreamCalled = false
+          var res = new Buffer('hello')
+          var fs = {
+              stat: function(file, cb) {
+                  statCalled = true
+                  cb(null, {
+                      size: res.length,
+                      ctime: new Date(),
+                      mtime: new Date(),
+                      ino: 0,
+                      isDirectory: function() {
+                          return false
+                      }
+                  })
+              },
+              createReadStream: function() {
+                  createReadStreamCalled = true
+                  var bam = stream.Readable()
+                  bam.push(res)
+                  bam.push(null)
+                  return bam;
+              }
+          }
+          var app = http.createServer(function(req, res){
+            send(req, req.url, {fs: fs})
+            .pipe(res);
+          })
+
+          request(app)
+          .get('/some/dir')
+          .expect(200, 'hello', function(err) {
+              if (err) return done(err)
+              assert.ok(statCalled)
+              assert.ok(createReadStreamCalled)
+              done()
+          })
+      })
   })
 })
 

--- a/test/send.js
+++ b/test/send.js
@@ -1280,13 +1280,14 @@ describe('send(file, options)', function(){
 
   describe('fs', function() {
       it('should invoke correct fs methods', function(done) {
+          var cb = after(3, done);
           var statCalled = false
           var createReadStreamCalled = false
           var res = new Buffer('hello')
           var fs = {
-              stat: function(file, cb) {
-                  statCalled = true
-                  cb(null, {
+              stat: function(file, next) {
+                  cb();
+                  next(null, {
                       size: res.length,
                       ctime: new Date(),
                       mtime: new Date(),
@@ -1297,7 +1298,7 @@ describe('send(file, options)', function(){
                   })
               },
               createReadStream: function() {
-                  createReadStreamCalled = true
+                  cb();
                   var bam = new ReadableStream()
                   bam.push(res)
                   bam.push(null)
@@ -1313,9 +1314,7 @@ describe('send(file, options)', function(){
           .get('/some/dir')
           .expect(200, 'hello', function(err) {
               if (err) return done(err)
-              assert.ok(statCalled)
-              assert.ok(createReadStreamCalled)
-              done()
+              cb();
           })
       })
   })


### PR DESCRIPTION
Options can now take an `fs` parameter which must emulate the functionality of `fs.stat` and `fs.createReadStream`.

The lovely webpack has `memory-fs` which (mostly) implements the required functions; but then they go and do something silly like rewrite a static file sender for `webpack-dev-middleware` when there's a perfectly good one here. This will enable the transport of files from `memory-fs` as if they were local.

See also https://github.com/webpack/memory-fs/pull/5
