### PR TITLE
Add support for transform option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ with a dot, for backward-compatibility.
 
 ##### etag
 
-Enable or disable etag generation, defaults to true.
+Enable or disable etag generation.
+
+Defaults to `true`, unless the `transform` option is set.
 
 ##### extensions
 
@@ -70,8 +72,10 @@ in preferred order.
 
 ##### lastModified
 
-Enable or disable `Last-Modified` header, defaults to true. Uses the file
-system's last modified value.
+Enable or disable `Last-Modified` header. Uses the file system's last modified
+value.
+
+Defaults to `true`, unless the `transform` option is set.
 
 ##### maxAge
 
@@ -82,6 +86,30 @@ This can also be a string accepted by the
 ##### root
 
 Serve files relative to `path`.
+
+##### transform
+
+A function that consumes the file stream and produces a new (transformed)
+stream:
+
+```javascript
+function(stream) {return stream.pipe(replaceStream('tobi', 'peter'))}
+```
+ 
+Multiple transformations are possible: 
+
+```javascript
+function(stream) {
+  return stream
+  .pipe(replaceStream('tobi', 'peter'))
+  .pipe(replaceStream('peter', 'hans'))
+  .pipe(...)
+}
+```
+
+When a transform is specified, the `lastModified` and `etag` options default to
+`false`, but can be overridden when a transform on the file's stream is expected
+to always generate the same result. 
 
 ### Events
 

--- a/index.js
+++ b/index.js
@@ -87,9 +87,13 @@ function SendStream(req, path, options) {
   this.path = path
   this.req = req
 
+  this._transform = typeof opts.transform === 'function'
+      ? options.transform
+      : undefined
+
   this._etag = opts.etag !== undefined
     ? Boolean(opts.etag)
-    : true
+    : (this._transform !== undefined ? false : true)
 
   this._dotfiles = opts.dotfiles !== undefined
     ? opts.dotfiles
@@ -120,7 +124,7 @@ function SendStream(req, path, options) {
 
   this._lastModified = opts.lastModified !== undefined
     ? Boolean(opts.lastModified)
-    : true
+    : (this._transform !== undefined ? false : true)
 
   this._maxage = opts.maxAge || opts.maxage
   this._maxage = typeof this._maxage === 'string'
@@ -592,7 +596,12 @@ SendStream.prototype.send = function(path, stat){
   opts.end = Math.max(offset, offset + len - 1)
 
   // content-length
-  res.setHeader('Content-Length', len);
+  if(this._transform === undefined){
+    res.setHeader('Content-Length', len);
+  } else {
+    //we don't know the content-length of the transformed data beforehand
+    res.setHeader('Transfer-Encoding', 'chunked');
+  }
 
   // HEAD support
   if ('HEAD' == req.method) return res.end();
@@ -691,6 +700,9 @@ SendStream.prototype.stream = function(path, options){
   // pipe
   var stream = fs.createReadStream(path, options);
   this.emit('stream', stream);
+  if(this._transform !== undefined) {
+    stream = this._transform(stream);
+  }
   stream.pipe(res);
 
   // response finished, done with the fd

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "after": "0.8.1",
     "istanbul": "0.3.9",
     "mocha": "2.2.5",
+    "readable-stream": "2.0.2",
     "supertest": "1.0.1"
   },
   "files": [


### PR DESCRIPTION
This is based on PR #69 by @peterbartels (see issue #71), but with conflicts resolved (and some typos in README.md fixed).

Adds a `transform` option, which allows the file stream to be transformed before piping it to `res`.
