### PR TITLE
Clarify dotfile documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,19 +37,21 @@ not the actual file-system path).
 ##### dotfiles
 
 Set how "dotfiles" are treated when encountered. A dotfile is a file
-or directory that begins with a dot ("."). Note this check is done on
-the path itself without checking if the path actually exists on the
-disk. If `root` is specified, only the dotfiles above the root are
-checked (i.e. the root itself can be within a dotfile when when set
-to "deny").
+or directory that begins with a dot (".").
 
+Note: This check is performed on the url pathname.
+It doesn't affect `root` and doesn't actually check if the path existence on disk.
+
+  - `undefined` (legacy) Ignore child dotfiles, but treat parents normally
+    - 404 `/.well-known`, `/.foo/.bar`
+    - 200 `/.well-known/existing-file`
   - `'allow'` No special treatment for dotfiles.
+    - 200 `/.exists`
+    - 404 `/.doesnt-exist`
   - `'deny'` Send a 403 for any request for a dotfile.
+    - 403 `/.exists`, `/.doesnt-exist`
   - `'ignore'` Pretend like the dotfile does not exist and 404.
-
-The default value is _similar_ to `'ignore'`, with the exception that
-this default will not ignore the files within a directory that begins
-with a dot, for backward-compatibility.
+    - 404 `/.exists`, `/.doesnt-exist`
 
 ##### etag
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ or directory that begins with a dot (".").
 Note: This check is performed on the url pathname.
 It doesn't affect `root` and doesn't actually check if the path existence on disk.
 
-  - `undefined` (legacy) Ignore child dotfiles, but treat parents normally
+  - **default behavior** Ignore child dotfiles, but treat parents normally.
     - 404 `/.well-known`, `/.foo/.bar`
     - 200 `/.well-known/existing-file`
   - `'allow'` No special treatment for dotfiles.

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ not the actual file-system path).
 Set how "dotfiles" are treated when encountered. A dotfile is a file
 or directory that begins with a dot (".").
 
-Note: This check is performed on the url pathname.
-It doesn't affect `root` and doesn't actually check if the path existence on disk.
+Note: This check is only performed on the path (of the url).
+It doesn't affect `root` (of the filesystem) and doesn't actually check for dotfiles on disk.
 
   - **default behavior** Ignore child dotfiles, but treat parents normally.
     - 404 `/.well-known`, `/.foo/.bar`


### PR DESCRIPTION
##### dotfiles

Set how "dotfiles" are treated when encountered. A dotfile is a file
or directory that begins with a dot (".").

Note: This check is only performed on the path (of the url).
It doesn't affect `root` (of the filesystem) and doesn't actually check for dotfiles on disk.

  - **default behavior** Ignore child dotfiles, but treat parents normally.
    - 404 `/.well-known`, `/.foo/.bar`
    - 200 `/.well-known/existing-file`
  - `'allow'` No special treatment for dotfiles.
    - 200 `/.exists`
    - 404 `/.doesnt-exist`
  - `'deny'` Send a 403 for any request for a dotfile.
    - 403 `/.exists`, `/.doesnt-exist`
  - `'ignore'` Pretend like the dotfile does not exist and 404.
    - 404 `/.exists`, `/.doesnt-exist`