### PR TITLE
Rename parameter to fix strict mode violation

### DIFF
--- a/index.js
+++ b/index.js
@@ -239,10 +239,10 @@ SendStream.prototype.maxage = deprecate.function(function maxage(maxAge) {
  * @private
  */
 
-SendStream.prototype.error = function error(status, error) {
+SendStream.prototype.error = function error(status, err) {
   // emit if listeners instead of responding
   if (listenerCount(this, 'error') !== 0) {
-    return this.emit('error', createError(error, status, {
+    return this.emit('error', createError(err, status, {
       expose: false
     }))
   }


### PR DESCRIPTION
When this module loaded into Safari (being included to bundle as a dependency), it cause following error:

"Cannot declare a parameter named 'error' as it shadows the name of a strict mode function."

So, to fix it I renamed 'error' parameter in 'error' function