### PR TITLE
added accepted options for etag

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ the 4th byte in the stream.
 
 ##### etag
 
-Enable or disable etag generation, defaults to true.
+Accepts `'weak'`, `'strong'`, custom function `function(data){ return etag}`,
+`true` for weak, `false` for disabled.
+Default is true.  
 
 ##### extensions
 

--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ function SendStream(req, path, options) {
   this.req = req
 
   this._etag = opts.etag !== undefined
-    ? Boolean(opts.etag)
+    ? opts.etag
     : true
 
   this._dotfiles = opts.dotfiles !== undefined
@@ -768,7 +768,12 @@ SendStream.prototype.setHeader = function setHeader(path, stat){
   }
 
   if (this._etag && !res.getHeader('ETag')) {
-    var val = etag(stat)
+    var val = null;
+    if(typeof this._etag == 'function') {
+        val = this._etag(stat);
+    } else {
+        val = etag(stat, {weak: this._etag == 'weak' || this._etag === true})
+    }
     debug('etag %s', val)
     res.setHeader('ETag', val)
   }

--- a/test/send.js
+++ b/test/send.js
@@ -102,6 +102,84 @@ describe('send(file).pipe(res)', function(){
     .expect('etag', /^W\/"[^"]+"$/)
     .end(done);
   })
+  
+  it('should add an ETag strong header field', function(done){
+    var app = http.createServer(function(req, res){
+    function error(err) {
+        res.statusCode = err.status;
+        res.end(http.STATUS_CODES[err.status]);
+    }
+
+    function redirect() {
+        res.statusCode = 301;
+        res.setHeader('Location', req.url + '/');
+        res.end('Redirecting to ' + req.url + '/');
+    }
+
+    send(req, req.url, {root: fixtures, etag: 'strong'})
+    .on('error', error)
+    .on('directory', redirect)
+    .pipe(res);
+    });
+    request(app)
+    .get('/name.txt')
+    .expect('etag', /^"[^"]+"$/)
+    .end(done);
+  })
+  
+  it('should not add an ETag header field', function(done){
+    var app = http.createServer(function(req, res){
+    function error(err) {
+        res.statusCode = err.status;
+        res.end(http.STATUS_CODES[err.status]);
+    }
+
+    function redirect() {
+        res.statusCode = 301;
+        res.setHeader('Location', req.url + '/');
+        res.end('Redirecting to ' + req.url + '/');
+    }
+
+    send(req, req.url, {root: fixtures, etag: false})
+    .on('error', error)
+    .on('directory', redirect)
+    .pipe(res);
+    });
+
+    request(app)
+    .get('/name.txt')
+    .end(function(err, res) {
+        if (err) {
+            return done(err);
+        }
+        assert.equal('etag' in res.headers, false);
+        done();
+    });
+  })
+  
+  it('should add an ETag custom header field', function(done){
+    var app = http.createServer(function(req, res){
+    function error(err) {
+        res.statusCode = err.status;
+        res.end(http.STATUS_CODES[err.status]);
+    }
+
+    function redirect() {
+        res.statusCode = 301;
+        res.setHeader('Location', req.url + '/');
+        res.end('Redirecting to ' + req.url + '/');
+    }
+
+    send(req, req.url, {root: fixtures, etag: function(){return 'test'}})
+    .on('error', error)
+    .on('directory', redirect)
+    .pipe(res);
+    });
+    request(app)
+    .get('/name.txt')
+    .expect('etag', 'test')
+    .end(done);
+  })
 
   it('should add a Date header field', function(done){
     request(app)


### PR DESCRIPTION
This PR adds funcionality for setting etags, 'weak' 'strong' custom function, without breaking back compatibility.

Needed for https://github.com/expressjs/express/pull/2936