### PR TITLE
Add support for multipart/byterange responses

### DIFF
--- a/index.js
+++ b/index.js
@@ -823,7 +823,7 @@ SendStream.prototype.streamMultipart = function streamMultipart (path, options) 
     // iterate through all the ranges
     asyncSeries(options.ranges, function (range, idx, next) {
       if (finished) return next()
-      var isLast = idx >= range.length - 1
+      var isLast = idx >= options.ranges.length - 1
       var partHeaders = (
         (idx ? CRLF : '') +
         '--' + BOUNDARY + CRLF +
@@ -1065,7 +1065,7 @@ function asyncSeries (array, iteratee, done) {
 /**
  * Only allow a function to run once
  *
- * @param {fn} function
+ * @param {function} fn
  * @private
  */
 

--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ var util = require('util')
  * @private
  */
 
+var basename = path.basename
 var extname = path.extname
 var join = path.join
 var normalize = path.normalize
@@ -70,6 +71,12 @@ var UP_PATH_REGEXP = /(?:^|[\\\/])\.\.(?:[\\\/]|$)/
 
 module.exports = send
 module.exports.mime = mime
+
+/**
+ * Is the node version is < 0.10
+ */
+
+var isLegacyNodeVersion = Boolean(EventEmitter.listenerCount)
 
 /**
  * Shim EventEmitter.listenerCount for node.js < 0.10
@@ -279,6 +286,9 @@ SendStream.prototype.error = function error (status, error) {
 
   var res = this.res
   var msg = statuses[status]
+
+  // do not set headers if they have already been sent
+  if (res._headerSent) return res.end()
 
   // clear existing headers
   clearHeaders(res)
@@ -620,17 +630,34 @@ SendStream.prototype.send = function send (path, stat) {
       })
     }
 
-    // valid (syntactically invalid/multiple ranges are treated as a regular response)
-    if (ranges !== -2 && ranges.length === 1) {
+    // valid (syntactically invalid treated as a regular response)
+    if (ranges !== -2) {
       debug('range %j', ranges)
 
       // Content-Range
       res.statusCode = 206
-      res.setHeader('Content-Range', contentRange('bytes', len, ranges[0]))
 
-      // adjust for requested range
-      offset += ranges[0].start
-      len = ranges[0].end - ranges[0].start + 1
+      if (ranges.length === 1) {
+        res.setHeader('Content-Range', contentRange('bytes', len, ranges[0]))
+        // adjust for requested range
+        offset += ranges[0].start
+        len = ranges[0].end - ranges[0].start + 1
+      } else if (ranges.length > 1) {
+        opts.boundary = 'BYTERANGE_' + Date.now()
+        opts.contentType = res.getHeader('Content-Type')
+        opts.fileSize = stat.size
+        opts.ranges = ranges
+        res.setHeader('Content-Disposition', 'attachment; filename="' + basename(path) + '"')
+        res.setHeader('Content-Type', 'multipart/byteranges; boundary=' + opts.boundary)
+        res.statusCode = 206
+        // HEAD support
+        if (req.method === 'HEAD') {
+          res.end()
+          return
+        }
+        this.streamMultipart(path, opts)
+        return
+      }
     }
   }
 
@@ -743,9 +770,11 @@ SendStream.prototype.stream = function stream (path, options) {
   // pipe
   var stream = fs.createReadStream(path, options)
   this.emit('stream', stream)
-  stream.pipe(res)
+  stream.once('open', function () {
+    stream.pipe(res)
+  })
 
-  // response finished, done with the fd
+  // response finished
   onFinished(res, function onfinished () {
     finished = true
     destroy(stream)
@@ -767,6 +796,71 @@ SendStream.prototype.stream = function stream (path, options) {
   // end
   stream.on('end', function onend () {
     self.emit('end')
+  })
+}
+
+/**
+ * Multipart Stream `path` to the response.
+ *
+ * @param {String} path
+ * @param {Object} options
+ * @api private
+ */
+
+SendStream.prototype.streamMultipart = function streamMultipart (path, options) {
+  var finished = false
+  var self = this
+  var res = this.res
+  var fileSize = options.fileSize
+  var BOUNDARY = options.boundary
+  var CRLF = '\r\n'
+  var stream
+
+  fs.open(path, 'r', function beginMultipartStream (err, fd) {
+    if (err) {
+      return self.onStatError(err)
+    }
+    // iterate through all the ranges
+    asyncSeries(options.ranges, function (range, idx, next) {
+      if (finished) return next()
+      var isLast = idx >= range.length - 1
+      var partHeaders = (
+        (idx ? CRLF : '') +
+        '--' + BOUNDARY + CRLF +
+        'Content-Type: ' + options.contentType + CRLF +
+        'Content-Range: ' + contentRange('bytes', fileSize, range) + CRLF +
+        CRLF
+      )
+      /* istanbul ignore next */
+      range.fd = isLegacyNodeVersion && idx ? null : fd
+      range.autoClose = isLast
+      stream = fs.createReadStream(path, range)
+      stream.on('error', next)
+      stream.on('end', function onpartend () { process.nextTick(next) })
+      if (!idx) self.emit('stream', stream)
+      res.write(partHeaders)
+      stream.pipe(res, { end: false })
+    }, function sentparts (err) {
+      if (finished) return
+      if (err) {
+        // clean up stream
+        finished = true
+        destroy(stream)
+
+        // error
+        self.onStatError(err)
+      } else {
+        res.end(CRLF + '--' + BOUNDARY + '--', function onend () {
+          self.emit('end')
+        })
+      }
+    })
+
+    // response finished
+    onFinished(res, function () {
+      finished = true
+      destroy(stream)
+    })
   })
 }
 
@@ -944,5 +1038,42 @@ function setHeaders (res, headers) {
   for (var i = 0; i < keys.length; i++) {
     var key = keys[i]
     res.setHeader(key, headers[key])
+  }
+}
+
+/**
+ * Applies the function `iteratee` to each item in `array` asynchronously in serial.
+ * The iteratee is called with an item from the array, its index, and a callback (next)
+ * for when it has finished. If the iteratee passes an error to its callback,
+ * the main callback (done) is immediately called with the error.
+ *
+ * @param {array} array
+ * @param {function} iteratee
+ * @param {function} [done]
+ * @private
+ */
+
+function asyncSeries (array, iteratee, done) {
+  var current = 0
+  var total = array.length
+  return (function next (err) {
+    if (err || total <= current) done(err)
+    else process.nextTick(function () { iteratee(array[current], current++, once(next)) })
+  })()
+}
+
+/**
+ * Only allow a function to run once
+ *
+ * @param {fn} function
+ * @private
+ */
+
+function once (fn) {
+  var invoked = false
+  return function () {
+    if (invoked) return invoked
+    invoked = true
+    return fn.apply(null, arguments)
   }
 }

--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ var willAlwaysCloseFileDescriptor = (function testAutoClose () {
   }).on('error', /* istanbul ignore next */ function (e) {
     willAlwaysCloseFileDescriptor = e.code === 'EBADF'
   }).on('data', function () {})
-  return false
+  return Boolean(EventEmitter.listenerCount)
 })()
 
 /**

--- a/index.js
+++ b/index.js
@@ -93,12 +93,10 @@ var willAlwaysCloseFileDescriptor = (function testAutoClose () {
     fs.close(fd)
   }).on('error', /* istanbul ignore next */ function (e) {
     switch (e.code) {
-      case 'OK': // AppVeyor is just flat out broken on node 0.8 apparently
+      case 'OK': // AppVeyor outputs an OK error in place of an EBADF error because reasons
       case 'EBADF': willAlwaysCloseFileDescriptor = true
     }
   }).on('data', function () {})
-  console.log('willAlwaysCloseFileDescriptor: typeof EventEmitter.listenerCount = ' + typeof EventEmitter.listenerCount)
-  console.log('willAlwaysCloseFileDescriptor: process.versions.node = ' + process.versions.node)
   return Number(process.versions.node[0]) === 0
 })()
 
@@ -875,7 +873,6 @@ SendStream.prototype.streamMultipart = function streamMultipart (path, options) 
     asyncSeries(options.ranges, function streamPart (range, idx, next) {
       if (finished) return next()
       var isLast = idx >= options.ranges.length - 1
-      console.log('willAlwaysCloseFileDescriptor = ' + willAlwaysCloseFileDescriptor)
       /* istanbul ignore next */
       range.fd = willAlwaysCloseFileDescriptor && idx ? null : fd
       range.autoClose = isLast

--- a/index.js
+++ b/index.js
@@ -85,18 +85,20 @@ module.exports.mime = mime
 
 var willAlwaysCloseFileDescriptor = (function testAutoClose () {
   var fd = fs.openSync('./package.json', 'r')
-  fs.createReadStream('./package.json', {
+  fs.createReadStream(null, {
     autoClose: false,
     fd: fd,
     end: 0
   }).on('end', function () {
-    console.log('willAlwaysCloseFileDescriptor: stream ended')
     fs.close(fd)
   }).on('error', /* istanbul ignore next */ function (e) {
-    console.log('willAlwaysCloseFileDescriptor: stream error = ' + e.code)
-    willAlwaysCloseFileDescriptor = e.code === 'EBADF'
+    switch (e.code) {
+      case 'OK': // AppVeyor is just flat out broken on node 0.8 apparently
+      case 'EBADF': willAlwaysCloseFileDescriptor = true
+    }
   }).on('data', function () {})
   console.log('willAlwaysCloseFileDescriptor: typeof EventEmitter.listenerCount = ' + typeof EventEmitter.listenerCount)
+  console.log('willAlwaysCloseFileDescriptor: process.versions.node = ' + process.versions.node)
   return Number(process.versions.node[0]) === 0
 })()
 

--- a/index.js
+++ b/index.js
@@ -85,16 +85,19 @@ module.exports.mime = mime
 
 var willAlwaysCloseFileDescriptor = (function testAutoClose () {
   var fd = fs.openSync('./package.json', 'r')
-  fs.createReadStream(null, {
+  fs.createReadStream('./package.json', {
     autoClose: false,
     fd: fd,
     end: 0
   }).on('end', function () {
+    console.log('willAlwaysCloseFileDescriptor: stream ended')
     fs.close(fd)
   }).on('error', /* istanbul ignore next */ function (e) {
+    console.log('willAlwaysCloseFileDescriptor: stream error = ' + e.code)
     willAlwaysCloseFileDescriptor = e.code === 'EBADF'
   }).on('data', function () {})
-  return typeof EventEmitter.listenerCount !== 'function'
+  console.log('willAlwaysCloseFileDescriptor: typeof EventEmitter.listenerCount = ' + typeof EventEmitter.listenerCount)
+  return Number(process.versions.node[0]) === 0
 })()
 
 /**
@@ -870,6 +873,7 @@ SendStream.prototype.streamMultipart = function streamMultipart (path, options) 
     asyncSeries(options.ranges, function streamPart (range, idx, next) {
       if (finished) return next()
       var isLast = idx >= options.ranges.length - 1
+      console.log('willAlwaysCloseFileDescriptor = ' + willAlwaysCloseFileDescriptor)
       /* istanbul ignore next */
       range.fd = willAlwaysCloseFileDescriptor && idx ? null : fd
       range.autoClose = isLast

--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ var willAlwaysCloseFileDescriptor = (function testAutoClose () {
   }).on('error', /* istanbul ignore next */ function (e) {
     willAlwaysCloseFileDescriptor = e.code === 'EBADF'
   }).on('data', function () {})
-  return Boolean(EventEmitter.listenerCount)
+  return typeof EventEmitter.listenerCount !== 'function'
 })()
 
 /**

--- a/test/send.js
+++ b/test/send.js
@@ -7,7 +7,6 @@ var fs = require('fs')
 var http = require('http')
 var path = require('path')
 var request = require('supertest')
-var formidable = require('formidable')
 var send = require('..')
 
 // test server
@@ -28,6 +27,12 @@ var app = http.createServer(function (req, res) {
 // This appears to be the best way to test multipart/byteranges
 // responses while using SuperTest. The SuperAgent `.parse()`
 // method doesn't work correctly when using SuperTest.
+var formidable
+try {
+  formidable = require('formidable')
+} catch (e) {
+  formidable = require('supertest/node_modules/superagent/node_modules/formidable')
+}
 formidable.IncomingForm.prototype.parse = function parseByteRanges (res, done) {
   var parts = []
   var totalLength = 0

--- a/test/send.js
+++ b/test/send.js
@@ -175,6 +175,25 @@ describe('send(file).pipe(res)', function () {
     .expect(404, done)
   })
 
+  it('should handle response ending before streaming finished', function (done) {
+    var app = http.createServer(function (req, res) {
+      send(req, req.url, {root: 'test/fixtures'})
+      .on('stream', function (stream) {
+        // simulate file error
+        process.nextTick(function () {
+          res.end('', function () {
+            stream.emit('error', new Error('boom!'))
+          })
+        })
+      })
+      .pipe(res)
+    })
+
+    request(app)
+    .get('/name.txt')
+    .expect(200, done)
+  })
+
   it('should 500 on file stream error', function (done) {
     var app = http.createServer(function (req, res) {
       send(req, req.url, {root: 'test/fixtures'})
@@ -518,20 +537,161 @@ describe('send(file).pipe(res)', function () {
     })
 
     describe('when multiple ranges', function () {
-      it('should respond with 200 and the entire contents', function (done) {
-        request(app)
-        .get('/nums')
-        .set('Range', 'bytes=1-1,3-')
-        .expect(shouldNotHaveHeader('Content-Range'))
-        .expect(200, '123456789', done)
+      describe('which can be combined', function () {
+        it('should respond with normal 206', function (done) {
+          request(app)
+          .get('/nums')
+          .set('Range', 'bytes=1-2,3-5')
+          .expect('Content-Range', 'bytes 1-5/9')
+          .expect(206, '23456', done)
+        })
       })
 
-      it('should respond with 206 is all ranges can be combined', function (done) {
-        request(app)
-        .get('/nums')
-        .set('Range', 'bytes=1-2,3-5')
-        .expect('Content-Range', 'bytes 1-5/9')
-        .expect(206, '23456', done)
+      describe('which cannot be combined', function () {
+        it('should respond with multipart 206', function (done) {
+          var body = ''
+          request(app)
+          .get('/nums')
+          .set('Range', 'bytes=0-1,3-3,5-6,7-8')
+          .buffer(true)
+          .parse(function (res, next) {
+            res.on('data', function (chunk) {
+              body += chunk
+            })
+          })
+          .expect(206)
+          .end(function (err, res) {
+            if (err) return done(err)
+            setTimeout(function () {
+              var parts = parseMultipartBody(body, res.boundary)
+              assert.equal(parts.length, 3)
+              assert.equal(parts[0].headers['Content-Range'], 'bytes 0-1/9')
+              assert.equal(parts[0].body, '12')
+              assert.equal(parts[1].headers['Content-Range'], 'bytes 3-3/9')
+              assert.equal(parts[1].body, '4')
+              assert.equal(parts[2].headers['Content-Range'], 'bytes 5-8/9')
+              assert.equal(parts[2].body, '6789')
+              done()
+            }, 20)
+          })
+        })
+
+        it('should support HEAD', function (done) {
+          request(app)
+          .head('/nums')
+          .set('Range', 'bytes=0-1,3-3,5-6,7-8')
+          .expect('Content-Disposition', 'attachment; filename="nums"')
+          .expect('Content-Type', /multipart\/byteranges;\sboundary=BYTERANGE_[0-9]+/)
+          .expect(206, undefined, done)
+        })
+
+        it('should 500 on file open error', function (done) {
+          var open = fs.open
+          fs.open = function (path, mode, cb) {
+            // simulate file error
+            setTimeout(function () {
+              var error = new Error('EMFILE: too many open files, open \'' + path + '\'')
+              error.code = 'EMFILE'
+              cb(error)
+            })
+          }
+          var app = http.createServer(function (req, res) {
+            send(req, req.url, {root: 'test/fixtures'}).pipe(res)
+          })
+
+          request(app)
+          .get('/nums')
+          .set('Range', 'bytes=0-1,3-3,5-6,7-8')
+          .expect(500, function (err, res) {
+            fs.open = open
+            done(err, res)
+          })
+        })
+
+        it('should handle file stream error after response partially written', function (done) {
+          var body = ''
+          var app = http.createServer(function (req, res) {
+            send(req, req.url, {root: 'test/fixtures'})
+            .on('stream', function (stream) {
+              process.nextTick(function () {
+                stream.emit('error', new Error('boom!'))
+              })
+            })
+            .pipe(res)
+          })
+
+          request(app)
+          .get('/nums')
+          .set('Range', 'bytes=0-1,3-3,5-6,7-8')
+          .buffer(true)
+          .parse(function (res, next) {
+            res.on('data', function (chunk) {
+              body += chunk
+            })
+          })
+          .expect(206, done)
+        })
+
+        it('should handle response ending before streaming finished', function (done) {
+          var body = ''
+          var app = http.createServer(function (req, res) {
+            send(req, req.url, {root: 'test/fixtures'})
+            .on('stream', function (stream) {
+              // simulate file error
+              stream.on('end', function () {
+                res.end()
+              })
+            })
+            .pipe(res)
+          })
+
+          request(app)
+          .get('/nums')
+          .set('Range', 'bytes=0-1,3-3,5-6,7-8')
+          .buffer(true)
+          .parse(function (res, next) {
+            res.on('data', function (chunk) {
+              body += chunk
+            })
+          })
+          .expect(206, done)
+        })
+
+        it('should stop streaming parts if any stream failed beyond the first', function (done) {
+          var body = ''
+          var app = http.createServer(function (req, res) {
+            send(req, req.url, {root: 'test/fixtures'})
+            .on('stream', function (stream) {
+              // simulate file error
+              stream.on('end', function () {
+                stream.emit('error', new Error('boom!'))
+              })
+            })
+            .pipe(res)
+          })
+
+          request(app)
+          .get('/nums')
+          .set('Range', 'bytes=0-1,3-3,5-6,7-8')
+          .buffer(true)
+          .parse(function (res, next) {
+            res.on('data', function (chunk) {
+              body += chunk
+            })
+          })
+          .expect(206)
+          .end(function (err, res) {
+            if (err) return done(err)
+            setTimeout(function () {
+              var parts = parseMultipartBody(body, res.boundary)
+              assert.equal(parts.length, 1)
+              assert.equal(parts[0].headers['Content-Range'], 'bytes 0-1/9')
+              var expected = typeof parts[0].body === 'undefined' || parts[0].body === '12'
+              assert.ok(expected, 'the first multipart body was either "12" or did not arrive')
+              done()
+            })
+          })
+        })
       })
     })
 
@@ -619,7 +779,7 @@ describe('send(file).pipe(res)', function () {
     })
 
     it('should support start/end with unsatisfiable Range request', function (done) {
-      request(createServer({root: fixtures, start: 0, end: 2}))
+      request(createServer({root: fixtures, start: 0, end: 2, hidden: false}))
       .get('/nums')
       .set('Range', 'bytes=5-9')
       .expect('Content-Range', 'bytes */3')
@@ -1294,4 +1454,20 @@ function shouldNotHaveHeader (header) {
   return function (res) {
     assert.ok(!(header.toLowerCase() in res.headers), 'should not have header ' + header)
   }
+}
+
+function parseMultipartBody (body, boundary) {
+  return body.split('--' + boundary).filter(function (part) {
+    return part && part !== '--'
+  }).map(function (part) {
+    var headBody = part.trim().split(/\r\n\r\n/g)
+    return {
+      headers: headBody[0].split(/\r\n/).reduce(function (memo, header) {
+        var keyVal = header.split(/:\s+/)
+        memo[keyVal[0]] = keyVal[1]
+        return memo
+      }, {}),
+      body: headBody[1]
+    }
+  })
 }

--- a/test/send.js
+++ b/test/send.js
@@ -637,7 +637,7 @@ describe('send(file).pipe(res)', function () {
           var app = http.createServer(function (req, res) {
             send(req, req.url, {root: 'test/fixtures'})
             .on('stream', function (stream) {
-              // simulate file error
+              // simulate response end
               stream.on('end', function () {
                 res.end()
               })


### PR DESCRIPTION
Properly handles byte-range requests with multiple non-overlapping ranges by responding with a multipart/byterange response. For details on the specification for handling this type of request see [RFC 7233](https://tools.ietf.org/html/rfc7233#section-4.1)

For example, a request looking like this:

```
GET /nums
Host: example.com
Range: bytes=0-1,3-3,5-6,7-8
```

Would generate a response like this:

```
HTTP/1.1 206 Partial Content
Accept-Ranges: bytes
ETag: W/"39aa72-153af0d74c0"
Content-Type: multipart/byteranges; boundary=BYTERANGE_IS5K8FWO
Content-Disposition: attachment; filename="nums"
Date: Tue, 02 Aug 2016 18:39:09 GMT
Content-Length: 311
Connection: close

--BYTERANGE_IS5K8FWO
Content-Type: application/octet-stream
Content-Range: bytes 0-1/9

12
--BYTERANGE_IS5K8FWO
Content-Type: application/octet-stream
Content-Range: bytes 3-3/9

4
--BYTERANGE_IS5K8FWO
Content-Type: application/octet-stream
Content-Range: bytes 5-8/9

6789
--BYTERANGE_IS5K8FWO--
```
