### PR TITLE
Prevent safari strict mode error

### DIFF
--- a/index.js
+++ b/index.js
@@ -269,7 +269,7 @@ SendStream.prototype.maxage = deprecate.function(function maxage (maxAge) {
  * @private
  */
 
-SendStream.prototype.error = function error (status, error) {
+SendStream.prototype.error = function (status, error) {
   // emit if listeners instead of responding
   if (listenerCount(this, 'error') !== 0) {
     return this.emit('error', createError(error, status, {

--- a/test/send.js
+++ b/test/send.js
@@ -1278,6 +1278,14 @@ describe('send.mime', function () {
   })
 })
 
+describe('safari compatibility', function () {
+  describe('.error function', function () {
+    it('does not used named function which causes strict mode error', function () {
+      assert.equal(new send().error.name, '')
+    })
+  })
+})
+
 function createServer (opts, fn) {
   return http.createServer(function onRequest (req, res) {
     try {


### PR DESCRIPTION
This is a fix for this issue https://github.com/pillarjs/send/issues/80

> SyntaxError: Cannot declare a parameter named 'error' as it shadows
the name of a strict mode function.

I've added a fairly descriptive test for this so that if the functionality is reversed then the test will catch it.

Why bother doing this?

I am running express in the browser with a virtual http layer between my http client and the server. This allows me to test a single page web application against the actual server without having to listen on any ports or pay any overhead of making an actual http request. This is enabled by https://www.npmjs.com/package/vinehill and I am testing my app with https://www.npmjs.com/package/browser-monkey - if you are interested.