### PR TITLE
Renamed error param to err; to fix Error in strict

### DIFF
--- a/index.js
+++ b/index.js
@@ -276,10 +276,10 @@ SendStream.prototype.maxage = deprecate.function(function maxage (maxAge) {
  * @private
  */
 
-SendStream.prototype.error = function error (status, error) {
+SendStream.prototype.error = function error (status, err) {
   // emit if listeners instead of responding
   if (listenerCount(this, 'error') !== 0) {
-    return this.emit('error', createError(status, error, {
+    return this.emit('error', createError(status, err, {
       expose: false
     }))
   }
@@ -292,8 +292,8 @@ SendStream.prototype.error = function error (status, error) {
   clearHeaders(res)
 
   // add error headers
-  if (error && error.headers) {
-    setHeaders(res, error.headers)
+  if (err && err.headers) {
+    setHeaders(res, err.headers)
   }
 
   // send basic response


### PR DESCRIPTION
SyntaxError: Cannot declare a parameter named 'error' in strict mode

Getting this error when running in phantomJS. Making this change fixes the SyntaxError and makes it go away!