### PR TITLE
add option autoEnd to append customized data after piped

### DIFF
--- a/index.js
+++ b/index.js
@@ -704,7 +704,8 @@ SendStream.prototype.send = function send (path, stat) {
   opts.end = Math.max(offset, offset + len - 1)
 
   // content-length
-  res.setHeader('Content-Length', len)
+  if(options.autoEnd!=undefined?options.autoEnd:true)
+      res.setHeader('Content-Length', len)
 
   // HEAD support
   if (req.method === 'HEAD') {
@@ -803,7 +804,7 @@ SendStream.prototype.stream = function stream (path, options) {
   // pipe
   var stream = fs.createReadStream(path, options)
   this.emit('stream', stream)
-  stream.pipe(res)
+  stream.pipe(res,{end:options.autoEnd!==undefined?options.autoEnd:true})
 
   // response finished, done with the fd
   onFinished(res, function onfinished () {

--- a/test/send.js
+++ b/test/send.js
@@ -24,6 +24,22 @@ var app = http.createServer(function (req, res) {
   .pipe(res)
 })
 
+var appPipeNotEnd = http.createServer(function (req, res) {
+  function error (err) {
+    res.statusCode = err.status
+    res.end(http.STATUS_CODES[err.status])
+  }
+
+  function end() {
+    res.end('tobi')
+  }
+
+  send(req, req.url, {root: fixtures,autoEnd:false,acceptRanges:false})
+      .on('error', error)
+      .on('end',end)
+      .pipe(res)
+})
+
 describe('send(file).pipe(res)', function () {
   it('should stream the file contents', function (done) {
     request(app)
@@ -1417,6 +1433,14 @@ describe('send.mime', function () {
       .expect(shouldNotHaveHeader('Content-Type'))
       .expect(200, done)
     })
+  })
+})
+
+describe('send(file).pipe(res,false)',function(){
+  it('should stream the file contents with append', function (done) {
+    request(appPipeNotEnd)
+        .get('/name.txt')
+        .expect(200, 'tobitobi', done)
   })
 })
 


### PR DESCRIPTION
add option autoEnd to give chance to append some customized data to the raw file。in the case of package tool, I want to auto add the module wrapper code to the raw JS in dev mode，to avoid the trouble for the package building。