### PR TITLE
add option to support pipe(res, { end: false })  in node.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,13 @@ Serve files relative to `path`.
 Byte offset at which the stream starts, defaults to 0. The start is inclusive,
 meaning `start: 2` will include the 3rd byte in the stream.
 
+##### autoEnd
+
+Enable or disable ending the stream of the http response  after pipe, defaults to true.
+Disabling this will ignore the header `Content-Length` which will force 
+the `Transfer-Encoding` to be `chunked`. User can listen the event `end` 
+for further operation. Here is the doc about [pipe]('https://nodejs.org/dist/latest-v6.x/docs/api/stream.html#stream_readable_pipe_destination_options').
+
 #### Events
 
 The `SendStream` is an event emitter and will emit the following events:

--- a/test/send.js
+++ b/test/send.js
@@ -24,6 +24,22 @@ var app = http.createServer(function (req, res) {
   .pipe(res)
 })
 
+var appPipeNotEnd = http.createServer(function (req, res) {
+  function error (err) {
+    res.statusCode = err.status
+    res.end(http.STATUS_CODES[err.status])
+  }
+
+  function end () {
+    res.end('tobi')
+  }
+
+  send(req, req.url, {root: fixtures, autoEnd: false, acceptRanges: false})
+      .on('error', error)
+      .on('end', end)
+      .pipe(res)
+})
+
 describe('send(file).pipe(res)', function () {
   it('should stream the file contents', function (done) {
     request(app)
@@ -1417,6 +1433,14 @@ describe('send.mime', function () {
       .expect(shouldNotHaveHeader('Content-Type'))
       .expect(200, done)
     })
+  })
+})
+
+describe('send(file).pipe(res,false)', function () {
+  it('should stream the file contents with append', function (done) {
+    request(appPipeNotEnd)
+        .get('/name.txt')
+        .expect(200, 'tobitobi', done)
   })
 })
 


### PR DESCRIPTION
add option autoEnd to match the raw API pipe from Stream in NodeJS. This option enable  append some customized data to the raw file。It make easy to implement BigPipe like function。it also help to add some hook code to handle JS module dependence when  downloading  JS file  async in Dev mode。