### PR TITLE
Update debug module version

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "server"
   ],
   "dependencies": {
-    "debug": "2.6.1",
+    "debug": "2.6.4",
     "depd": "~1.1.0",
     "destroy": "~1.0.4",
     "encodeurl": "~1.0.1",


### PR DESCRIPTION
This version fixes the issue described here https://github.com/visionmedia/debug/issues/443
> If process.env.DEBUG is set to a value other than a string a TypeError occurs. This can easily happen when using webpack to build a project.