### PR TITLE
Add support for Cache-Control: immutable

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,11 @@ system's last modified value.
 
 Provide a max-age in milliseconds for http caching, defaults to 0.
 This can also be a string accepted by the
-[ms](https://www.npmjs.org/package/ms#readme) module.
+[ms](https://www.npmjs.org/package/ms#readme) module. The maximum max-age
+is 1 year or 31536000000ms. If set to `Infinity` the [`immutable` Cache-Control
+directive](https://bitsup.blogspot.de/2016/05/cache-control-immutable.html) will
+be added (e.g. `Cache-Control: public, max-age=31536000, immutable`).
+
 
 ##### root
 

--- a/index.js
+++ b/index.js
@@ -165,6 +165,7 @@ function SendStream (req, path, options) {
   this._maxage = typeof this._maxage === 'string'
     ? ms(this._maxage)
     : Number(this._maxage)
+  this._immutable = this._maxage === Infinity ? ', immutable' : ''
   this._maxage = !isNaN(this._maxage)
     ? Math.min(Math.max(0, this._maxage), MAX_MAXAGE)
     : 0
@@ -876,7 +877,7 @@ SendStream.prototype.setHeader = function setHeader (path, stat) {
   }
 
   if (this._cacheControl && !res.getHeader('Cache-Control')) {
-    var cacheControl = 'public, max-age=' + Math.floor(this._maxage / 1000)
+    var cacheControl = 'public, max-age=' + Math.floor(this._maxage / 1000) + this._immutable
     debug('cache-control %s', cacheControl)
     res.setHeader('Cache-Control', cacheControl)
   }

--- a/test/send.js
+++ b/test/send.js
@@ -1226,9 +1226,15 @@ describe('send(file, options)', function () {
     })
 
     it('should max at 1 year', function (done) {
-      request(createServer({maxAge: Infinity, root: fixtures}))
+      request(createServer({maxAge: '2y', root: fixtures}))
       .get('/name.txt')
       .expect('Cache-Control', 'public, max-age=31536000', done)
+    })
+
+    it('should set "immutable" if set to Infinity', function (done) {
+      request(createServer({maxAge: Infinity, root: fixtures}))
+      .get('/name.txt')
+      .expect('Cache-Control', 'public, max-age=31536000, immutable', done)
     })
   })
 


### PR DESCRIPTION
If the `maxAge` option is set to `Infinity` then the resulting header will be set:

```
Cache-Control: public, max-age=31536000, immutable
```

Resolves https://github.com/expressjs/express/issues/3197