### PR TITLE
deps: mime@1.4.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,12 @@
+0.16.0 / 2017-09-29
+===================
+
+  * deps: mime@1.4.0
+    - Register `.md` to be `text/markdown`
+    - Register `.mjs` to be `application/javascript`
+    - Register `.gz` to be `application/gzip`
+    - `font/opentype` is now `font/otf` as it has been [officially registered](https://www.iana.org/assignments/media-types/font/otf)
+
 0.15.4 / 2017-08-05
 ===================
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "etag": "~1.8.0",
     "fresh": "0.5.0",
     "http-errors": "~1.6.2",
-    "mime": "1.3.4",
+    "mime": "1.4.0",
     "ms": "2.0.0",
     "on-finished": "~2.3.0",
     "range-parser": "~1.2.0",


### PR DESCRIPTION
pulls in the updated version `1.30.0` of [mime-db](https://github.com/jshttp/mime-db)

of note is migration of MIME `font/otf` and `.mjs` for `application/javascript`

https://github.com/broofa/node-mime/pull/166