### PR TITLE
Bump mime to 1.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "etag": "~1.8.1",
     "fresh": "0.5.2",
     "http-errors": "~1.6.2",
-    "mime": "1.4.0",
+    "mime": "1.4.1",
     "ms": "2.0.0",
     "on-finished": "~2.3.0",
     "range-parser": "~1.2.0",


### PR DESCRIPTION
This version fixes a security vulnerability flagged by snyk (https://github.com/expressjs/express/issues/3431) and nsp (https://nodesecurity.io/advisories/535) that's been fixed upstream.