### PR TITLE
api: Added ability to set custom `fs` module

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,6 +69,9 @@ var UP_PATH_REGEXP = /(?:^|[\\/])\.\.(?:[\\/]|$)/
 
 module.exports = send
 module.exports.mime = mime
+module.exports.setFsModule = function (vfs) {
+  fs = vfs;
+}
 
 /**
  * Return a `SendStream` for `req` and `path`.

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ var UP_PATH_REGEXP = /(?:^|[\\/])\.\.(?:[\\/]|$)/
 module.exports = send
 module.exports.mime = mime
 module.exports.setFsModule = function (vfs) {
-  fs = vfs;
+  fs = vfs
 }
 
 /**


### PR DESCRIPTION
This PR adds the ability to set a custom `fs` module for use inside of `send` module.

I needed this because I have another `fs` API compatible library for cloud files and I wanted to utilize `send` for serving static content from remote file sources. It's actually working great, so thank you!

Pseudo Example Usage:

```js
var send = require('send');
var remoteFs = require('the-remote-fs-module');
send.setFsModule(remoteFs);
// now use send() as normal, but will send remote files
```

Would you be willing to accept this PR into the library? It should be very harmless. Please let me know. I can make adjustments or add a simple test.