### PR TITLE
Upgrade to mime@1.5.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "etag": "~1.8.1",
     "fresh": "0.5.2",
     "http-errors": "~1.6.2",
-    "mime": "1.4.1",
+    "mime": "^1.5.0",
     "ms": "2.0.0",
     "on-finished": "~2.3.0",
     "range-parser": "~1.2.0",


### PR DESCRIPTION
There are newer versions of this package available, but 1.5.0 includes support for the application/wasm mime type, which I need in a dependency several packages removed. If you wanted to reject this in favor of a major version bump then I'd understand, but this seems to be the smallest change that would meet my requirements. Thanks!