### PR TITLE
[URGENT][SECURITY] Keep Content-Security-Policy http header in 304 requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -360,7 +360,7 @@ SendStream.prototype.removeContentHeaderFields = function removeContentHeaderFie
 
   for (var i = 0; i < headers.length; i++) {
     var header = headers[i]
-    if (header.substr(0, 8) === 'content-' && header !== 'content-location') {
+    if (header.substr(0, 8) === 'content-' && header !== 'content-location' && !header.includes('content-security-policy')) {
       res.removeHeader(header)
     }
   }

--- a/test/send.js
+++ b/test/send.js
@@ -418,6 +418,8 @@ describe('send(file).pipe(res)', function () {
         res.setHeader('Content-Language', 'en-US')
         res.setHeader('Content-Location', 'http://localhost/name.txt')
         res.setHeader('Contents', 'foo')
+        res.setHeader('Content-Security-Policy', 'default-src \'self\'')
+        res.setHeader('Content-Security-Policy-Report-Only', 'default-src https:; report-uri /csp-violation-report-endpoint/')
       })
 
       request(server)
@@ -432,6 +434,8 @@ describe('send(file).pipe(res)', function () {
             .expect(shouldNotHaveHeader('Content-Type'))
             .expect('Content-Location', 'http://localhost/name.txt')
             .expect('Contents', 'foo')
+            .expect('Content-Security-Policy', 'default-src \'self\'')
+            .expect('Content-Security-Policy-Report-Only', 'default-src https:; report-uri /csp-violation-report-endpoint/')
             .expect(304, done)
         })
     })


### PR DESCRIPTION
Hi there,

we have found out that Content-Security-Policy http-headers are being dumped in case of 304 (Not Modified) requests which brings security problems/risks for the enterprise applications and makes it impossible to use this this library in a production environment.

Please consider to keep these very important http headers in any kind of requests.


Thanks,
Pavel