### PR TITLE
Remove line in SendStream.pipe() that does nothing

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@ unreleased
     - deps: setprototypeof@1.1.0
     - deps: statuses@'>= 1.3.1 < 2'
   * deps: statuses@~1.5.0
+  * perf: remove redundant `path.normalize` call
 
 0.16.2 / 2018-02-07
 ===================

--- a/index.js
+++ b/index.js
@@ -546,7 +546,6 @@ SendStream.prototype.pipe = function pipe (res) {
 
     // join / normalize from optional root dir
     path = normalize(join(root, path))
-    root = normalize(root + sep)
   } else {
     // ".." is malicious without "root"
     if (UP_PATH_REGEXP.test(path)) {


### PR DESCRIPTION
This line looks like it was left over from the refactor in this commit: https://github.com/pillarjs/send/commit/98a5b89982b38e79db684177cf94730ce7fc7aed

You can see in that commit that `root` used to be used, but afterwards it appears to serve no purpose, unless I'm missing something.