### PR TITLE
check mime Version, use correct mime Function

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@ unreleased
     - deps: setprototypeof@1.1.0
     - deps: statuses@'>= 1.3.1 < 2'
   * deps: statuses@~1.5.0
+  * perf: remove redundant `path.normalize` call
 
 0.16.2 / 2018-02-07
 ===================

--- a/index.js
+++ b/index.js
@@ -835,16 +835,16 @@ SendStream.prototype.type = function type (path) {
 
   if (res.getHeader('Content-Type')) return
 
-  var type;
-  var mimeVersion = null;
+  var type
+  var mimeVersion = null
   // check mime version <= 1
   if (typeof mime.lookup === 'function') {
-    type = mime.lookup(path);
-    mimeVersion = 1;
+    type = mime.lookup(path)
+    mimeVersion = 1
   }
   // check mime version >= 2
   if (typeof mime.getType === 'function') {
-    type = mime.getType(path);
+    type = mime.getType(path)
   }
 
   if (!type) {
@@ -852,10 +852,10 @@ SendStream.prototype.type = function type (path) {
     return
   }
 
-  var charset;
+  var charset
   // mime version >= 2 removed function charsets
   if (mimeVersion === 1) {
-    charset = mime.charsets.lookup(type);
+    charset = mime.charsets.lookup(type)
   }
 
   debug('content-type %s', type)

--- a/index.js
+++ b/index.js
@@ -835,14 +835,28 @@ SendStream.prototype.type = function type (path) {
 
   if (res.getHeader('Content-Type')) return
 
-  var type = mime.lookup(path)
+  var type;
+  var mimeVersion = null;
+  // check mime version <= 1
+  if (typeof mime.lookup === 'function') {
+    type = mime.lookup(path);
+    mimeVersion = 1;
+  }
+  // check mime version >= 2
+  if (typeof mime.getType === 'function') {
+    type = mime.getType(path);
+  }
 
   if (!type) {
     debug('no content-type')
     return
   }
 
-  var charset = mime.charsets.lookup(type)
+  var charset;
+  // mime version >= 2 removed function charsets
+  if (mimeVersion === 1) {
+    charset = mime.charsets.lookup(type);
+  }
 
   debug('content-type %s', type)
   res.setHeader('Content-Type', type + (charset ? '; charset=' + charset : ''))

--- a/index.js
+++ b/index.js
@@ -546,7 +546,6 @@ SendStream.prototype.pipe = function pipe (res) {
 
     // join / normalize from optional root dir
     path = normalize(join(root, path))
-    root = normalize(root + sep)
   } else {
     // ".." is malicious without "root"
     if (UP_PATH_REGEXP.test(path)) {


### PR DESCRIPTION
Polymer 3 uses Yarn as Package-Manager and [needs](https://www.polymer-project.org/blog/2017-08-23-hands-on-30-preview) the [--flat](https://yarnpkg.com/lang/en/docs/cli/install/#toc-yarn-install-flat) option set.

send has [mime](https://www.npmjs.com/package/mime) as dependency and there are some breaking changes between mime v1 and mime v2. 

With the need for the yarn --flat option in Polymer 3, only one Version of mime can be installed for the project. So, if i have mime v2 installed (remember,yarn --flat allows only one Version per package), send calls `mime.lookup` and `mime.charset` wich are not available in mime v2.

The commit tests wich function is available in send (send v1 uses lookup(), send v2 uses getType()) and uses the recognized function.