### PR TITLE
Proposal: Add host option to override node fs and path modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ not the actual file-system path).
 
 #### Options
 
+##### host
+
+Enable override of the default nodejs `fs` and `path`.
+use this option to enable in memory or remote sources support 
+Default value: `{ fs: require('fs'), path: require('path') }`
+
 ##### acceptRanges
 
 Enable or disable accepting ranged requests, defaults to true.


### PR DESCRIPTION
Hi,
I have a use-case that requires me to serve files from memory in my tests.
Currently, I use `express.static()` from `serve-static` which uses this package. Now, I want to keep the same API but enable passing an option to override the default host file-system and path resolution.
There is an [issue](expressjs/serve-static#83) in `express-static` that requests the same thing but hasn't seen much activity.


About the tests missing from this pull request.
Since there is no changed behavior, all of the current tests are passing. What I would really want to do is wrap all the existing test-cases in a factory and re-run them using an external host.
Would you have any objections to this test plan? Would love to get this in.

