### PR TITLE
Deprecated res._headers method replaced with Node12 complaint res.getHeaders

### DIFF
--- a/index.js
+++ b/index.js
@@ -1002,7 +1002,7 @@ function decode (path) {
 
 function getHeaderNames (res) {
   return typeof res.getHeaderNames !== 'function'
-    ? Object.keys(res._headers || {})
+    ? Object.keys(res.getHeaders || {})
     : res.getHeaderNames()
 }
 

--- a/index.js
+++ b/index.js
@@ -993,7 +993,7 @@ function decode (path) {
 }
 
 /**
- * Get the header names on a respnse.
+ * Get the header names on a response.
  *
  * @param {object} res
  * @returns {array[string]}
@@ -1002,7 +1002,7 @@ function decode (path) {
 
 function getHeaderNames (res) {
   return typeof res.getHeaderNames !== 'function'
-    ? Object.keys(res.getHeaders || {})
+    ? Object.keys(typeof res.getHeaders === 'function' ? res.getHeaders : res._headers || {})
     : res.getHeaderNames()
 }
 


### PR DESCRIPTION
res._headers causes `[DEP0066] DeprecationWarning: OutgoingMessage.prototype._headers is deprecated in Node.js 12 runtime warning`
Replaced with public `res.getHeaders` method
Links: [Node docs](https://nodejs.org/api/deprecations.html#deprecations_dep0066_outgoingmessage_headers_outgoingmessage_headernames), [res.hetHeaders](https://nodejs.org/api/http.html#http_response_getheaders)
