### PR TITLE
feat: added transform option

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+Unreleased
+===================
+
+  * Add `transform` option
+
 0.17.1 / 2019-05-10
 ===================
 
@@ -455,37 +460,37 @@
 
  * update range-parser and fresh
 
-0.1.4 / 2013-08-11 
+0.1.4 / 2013-08-11
 ==================
 
  * update fresh
 
-0.1.3 / 2013-07-08 
+0.1.3 / 2013-07-08
 ==================
 
  * Revert "Fix fd leak"
 
-0.1.2 / 2013-07-03 
+0.1.2 / 2013-07-03
 ==================
 
  * Fix fd leak
 
-0.1.0 / 2012-08-25 
+0.1.0 / 2012-08-25
 ==================
 
   * add options parameter to send() that is passed to fs.createReadStream() [kanongil]
 
-0.0.4 / 2012-08-16 
+0.0.4 / 2012-08-16
 ==================
 
   * allow custom "Accept-Ranges" definition
 
-0.0.3 / 2012-07-16 
+0.0.3 / 2012-07-16
 ==================
 
   * fix normalization of the root directory. Closes #3
 
-0.0.2 / 2012-07-09 
+0.0.2 / 2012-07-09
 ==================
 
   * add passing of req explicitly for now (YUCK)

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "after": "0.8.2",
+    "concat-stream": "1.6.2",
     "eslint": "5.16.0",
     "eslint-config-standard": "12.0.0",
     "eslint-plugin-import": "2.17.2",


### PR DESCRIPTION
Prior work:

- https://github.com/pillarjs/send/pull/69
- https://github.com/pillarjs/send/pull/82
- https://github.com/pillarjs/send/pull/171
- https://github.com/TimBarham/send/tree/transform-0.15

Adds a `transform` option.  Allows users to transform inflight requests.

Things to note:

1. As discussed in previous threads, when using the `transform` option it can invalidate `etag` and `last-modified`. I added documentation to that effect and set the defaults to `false` when `transform` is passed.
2. Range requests, again as discussed previously, will behave oddly if you are not aware that your stream might not get a complete file.  Also documented with a warning to set `acceptRanges: false` if you cannot write a transform which handles this kind of request.
3. Compared to previous PRs, I added the `res` and `opts` to the function, this should make it easier to implement transforms which support range and other types of requests.

I think this resolves all the open conversations on the topic I saw from before.  Let me know what you all think!