### PR TITLE
Fix Issue #200

### DIFF
--- a/index.js
+++ b/index.js
@@ -835,7 +835,8 @@ SendStream.prototype.type = function type (path) {
 
   if (res.getHeader('Content-Type')) return
 
-  var type = mime.lookup(path)
+  var type;
+  if (mime.lookup) type = mime.lookup(path)
 
   if (!type) {
     debug('no content-type')


### PR DESCRIPTION
**Error:** `mime.lookup is not a function`
**Solution:** Function is checked before use. No difference in functionality but fixes critical error for some dependent modules.

I do not know why `mime.lookup` is undefined, but this has stopped me from using other packages that are dependent on send and has required me to continuously change this piece of code each time to be able to build my project. I would be grateful if this was merged and included in the next release.