### PR TITLE
deps: debug@3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "server"
   ],
   "dependencies": {
-    "debug": "2.6.9",
+    "debug": "3.1.0",
     "depd": "2.0.0",
     "destroy": "1.2.0",
     "encodeurl": "~1.0.2",


### PR DESCRIPTION
Demo library version 2.6.9 has vulnerability issues and we should update it to at least version 3.1.0 
Here is the link for more information:  [https://vulners.com/osv/OSV:GHSA-9VVW-CC9W-F27H](https://vulners.com/osv/OSV:GHSA-9VVW-CC9W-F27H)
![image](https://user-images.githubusercontent.com/60115295/217826931-d0e25db0-0e02-4942-a215-19b3b87fcb8b.png)

All tests passed without issues
![image](https://user-images.githubusercontent.com/60115295/217827110-d2f0f85d-8964-488e-9354-541ba56ab96e.png)

