### PR TITLE
Do not serve files when path ends with /

### DIFF
--- a/index.js
+++ b/index.js
@@ -605,12 +605,16 @@ SendStream.prototype.sendFile = function sendFile (path) {
 
   debug('stat "%s"', path)
   fs.stat(path, function onstat (err, stat) {
-    if (err && err.code === 'ENOENT' && !extname(path) && path[path.length - 1] !== sep) {
+    var pathEndsWithSep = path[path.length - 1] === sep
+    
+    if (err && err.code === 'ENOENT' && !extname(path) && !pathEndsWithSep) {
       // not found, check extensions
       return next(err)
     }
     if (err) return self.onStatError(err)
     if (stat.isDirectory()) return self.redirect(path)
+    if(pathEndsWithSep) return self.error(404)
+    
     self.emit('file', path, stat)
     self.send(path, stat)
   })

--- a/index.js
+++ b/index.js
@@ -606,15 +606,13 @@ SendStream.prototype.sendFile = function sendFile (path) {
   debug('stat "%s"', path)
   fs.stat(path, function onstat (err, stat) {
     var pathEndsWithSep = path[path.length - 1] === sep
-    
     if (err && err.code === 'ENOENT' && !extname(path) && !pathEndsWithSep) {
       // not found, check extensions
       return next(err)
     }
     if (err) return self.onStatError(err)
     if (stat.isDirectory()) return self.redirect(path)
-    if(pathEndsWithSep) return self.error(404)
-    
+    if (pathEndsWithSep) return self.error(404)
     self.emit('file', path, stat)
     self.send(path, stat)
   })

--- a/test/send.js
+++ b/test/send.js
@@ -1194,6 +1194,12 @@ describe('send(file, options)', function () {
         .get('/')
         .expect(200, /tobi/, done)
     })
+
+    it('should 404 if file path contains tralling slash (windows)', function (done) {
+      request(createServer({ root: fixtures, index: false }))
+        .get('/tobi.html/')
+        .expect(404, done)
+    })
   })
 
   describe('root', function () {

--- a/test/send.js
+++ b/test/send.js
@@ -1195,7 +1195,7 @@ describe('send(file, options)', function () {
         .expect(200, /tobi/, done)
     })
 
-    it('should 404 if file path contains tralling slash (windows)', function (done) {
+    it('should 404 if file path contains trailing slash (windows)', function (done) {
       request(createServer({ root: fixtures, index: false }))
         .get('/tobi.html/')
         .expect(404, done)


### PR DESCRIPTION
When `index` option is set to `false` and the environment is Windows, requests that end with a `/` might result in serving files. This happens because in Windows, when accessing a file or directory, if the path ends with `/`, the system first checks for a directory. If no directory is found, it then checks if a file with the same name exists, ignoring the `/` at the end of the path. This enables access to a file unexpectedly, as if the path did not conclude with `/`.

The proposed fix addresses this issue by introducing a check to ensure that the path does not ends with `/` before serving a file. For example, in the given case, file is being accessed when it should not be, and the proposed change aims to rectify this behavior.

`index.js`
```JS
var http = require("http");
var send = require("send");

var server = http.createServer(function onRequest(req, res) {
  send(req, "./index.html/", { index: false }).pipe(res);
});

server.listen(3000);
```
`index.html`
```HTML
<!DOCTYPE html>
<html lang="en">
  <head>
    <meta charset="UTF-8" />
    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    <title>Document</title>
  </head>
  <body>
    HTML File
  </body>
</html>
```