### PR TITLE
Update Dev Deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-promise": "5.2.0",
     "eslint-plugin-standard": "4.1.0",
-    "mocha": "9.2.2",
+    "mocha": "^10.7.0",
     "nyc": "15.1.0",
     "supertest": "6.2.2"
   },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "statuses": "2.0.1"
   },
   "devDependencies": {
-    "after": "0.8.2",
+    "after": "^0.8.2",
     "eslint": "7.32.0",
     "eslint-config-standard": "14.1.1",
     "eslint-plugin-import": "2.25.4",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "eslint-plugin-promise": "5.2.0",
     "eslint-plugin-standard": "4.1.0",
     "mocha": "^10.7.0",
-    "nyc": "15.1.0",
+    "nyc": "^17.0.0",
     "supertest": "6.2.2"
   },
   "files": [


### PR DESCRIPTION
This updates a few dev deps. It moves to using `^` so we have less updates to apply on a regular basis. Also it does not update eslint as I think we should update that to use `standard` if we are going to deal with the complexity of actually updating a set of eslint plugins. It also doesn't update `supertest` because of this: https://github.com/ladjs/superagent/pull/1802#issuecomment-2244066490

