### PR TITLE
Update all prod deps to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "http-errors": "^2.0.0",
     "mime-types": "^2.1.35",
     "ms": "^2.1.3",
-    "on-finished": "2.4.1",
+    "on-finished": "^2.4.1",
     "range-parser": "~1.2.1",
     "statuses": "2.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "debug": "^4.3.5",
     "destroy": "^1.2.0",
-    "encodeurl": "~1.0.2",
+    "encodeurl": "^2.0.0",
     "escape-html": "~1.0.3",
     "etag": "~1.8.1",
     "fresh": "0.5.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "debug": "^4.3.5",
     "destroy": "^1.2.0",
     "encodeurl": "^2.0.0",
-    "escape-html": "~1.0.3",
+    "escape-html": "^1.0.3",
     "etag": "~1.8.1",
     "fresh": "0.5.2",
     "http-errors": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "encodeurl": "^2.0.0",
     "escape-html": "^1.0.3",
     "etag": "^1.8.1",
-    "fresh": "0.5.2",
+    "fresh": "^0.5.2",
     "http-errors": "2.0.0",
     "mime-types": "~2.1.34",
     "ms": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "ms": "^2.1.3",
     "on-finished": "^2.4.1",
     "range-parser": "^1.2.1",
-    "statuses": "2.0.1"
+    "statuses": "^2.0.1"
   },
   "devDependencies": {
     "after": "^0.8.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "dependencies": {
     "debug": "^4.3.5",
-    "destroy": "1.2.0",
+    "destroy": "^1.2.0",
     "encodeurl": "~1.0.2",
     "escape-html": "~1.0.3",
     "etag": "~1.8.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "destroy": "^1.2.0",
     "encodeurl": "^2.0.0",
     "escape-html": "^1.0.3",
-    "etag": "~1.8.1",
+    "etag": "^1.8.1",
     "fresh": "0.5.2",
     "http-errors": "2.0.0",
     "mime-types": "~2.1.34",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "mime-types": "^2.1.35",
     "ms": "^2.1.3",
     "on-finished": "^2.4.1",
-    "range-parser": "~1.2.1",
+    "range-parser": "^1.2.1",
     "statuses": "2.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "fresh": "^0.5.2",
     "http-errors": "^2.0.0",
     "mime-types": "^2.1.35",
-    "ms": "2.1.3",
+    "ms": "^2.1.3",
     "on-finished": "2.4.1",
     "range-parser": "~1.2.1",
     "statuses": "2.0.1"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "server"
   ],
   "dependencies": {
-    "debug": "3.1.0",
+    "debug": "^4.3.5",
     "destroy": "1.2.0",
     "encodeurl": "~1.0.2",
     "escape-html": "~1.0.3",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "escape-html": "^1.0.3",
     "etag": "^1.8.1",
     "fresh": "^0.5.2",
-    "http-errors": "2.0.0",
+    "http-errors": "^2.0.0",
     "mime-types": "~2.1.34",
     "ms": "2.1.3",
     "on-finished": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "etag": "^1.8.1",
     "fresh": "^0.5.2",
     "http-errors": "^2.0.0",
-    "mime-types": "~2.1.34",
+    "mime-types": "^2.1.35",
     "ms": "2.1.3",
     "on-finished": "2.4.1",
     "range-parser": "~1.2.1",


### PR DESCRIPTION
As the title states. Landing this in 1.0.0 is nice because it means any breakage from these dep updates is covered in the major. That said, none of the tests failed so I think they are all relatively safe. Also worth calling out is I am moving to `^` ranges for all deps going forward to reduce maintainer burden.