### PR TITLE
fix: remove obsolete dependency `destroy`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,7 @@ unreleased
 
   * deps: 
     * `fresh@^2.0.0` 
+    * removed `destroy`
 
 1.1.0 / 2024-09-10
 ==================

--- a/index.js
+++ b/index.js
@@ -14,7 +14,6 @@
 
 var createError = require('http-errors')
 var debug = require('debug')('send')
-var destroy = require('destroy')
 var encodeUrl = require('encodeurl')
 var escapeHtml = require('escape-html')
 var etag = require('etag')
@@ -684,7 +683,7 @@ SendStream.prototype.stream = function stream (path, options) {
 
   // cleanup
   function cleanup () {
-    destroy(stream, true)
+    stream.destroy()
   }
 
   // response finished, cleanup

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   ],
   "dependencies": {
     "debug": "^4.3.5",
-    "destroy": "^1.2.0",
     "encodeurl": "^2.0.0",
     "escape-html": "^1.0.3",
     "etag": "^1.8.1",


### PR DESCRIPTION
The [`destroy`](https://www.npmjs.com/package/destroy) package was was used to handle stream destruction across legacy Node.js versions (>=0.8), addressing bugs in specific versions. Since we now officially support only Node.js 18 and newer, we can safely remove this dependency and replace it with a direct call to `stream.destroy()`.

Related to: 

* https://github.com/expressjs/body-parser/pull/570

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->