### PR TITLE
Release: 0.19.2

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,4 @@
-unreleased
+0.19.2 / 2025-12-15
 ===================
 
 * deps: use tilde notation for dependencies

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "send",
   "description": "Better streaming static file server with Range and conditional-GET support",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
   "contributors": [
     "Douglas Christopher Wilson <doug@somethingdoug.com>",


### PR DESCRIPTION
## What's included in the `HISTORY.md` 

```
0.19.2 / 2025-12-15
===================

* deps: use tilde notation for dependencies
* deps: http-errors@~2.0.1
* deps: statuses@~2.0.2

```
## What's Changed
* fix(deps): encodeurl@~2.0.0 by @wesleytodd in https://github.com/pillarjs/send/pull/240
* deps: use tilde notation and update certain dependencies by @Phillip9587 in https://github.com/pillarjs/send/pull/279


**Full Changelog**: https://github.com/pillarjs/send/compare/0.19.0...0.x