### PR TITLE
Enhance send to stream special files safely

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Serve files relative to `path`.
 
 ##### allowSpecialFiles
 
-When true Serve files in linux based systems ( in folders like /proc ), defaiult false files return a size=0.
+When true Serve files in linux based systems ( in folders like /proc ), default is set to false and files return a size=0.
 
 ##### start
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ This can also be a string accepted by the
 
 Serve files relative to `path`.
 
+##### allowSpecialFiles
+
+When true Serve files in linux based systems ( in folders like /proc ), defaiult false files return a size=0.
+
 ##### start
 
 Byte offset at which the stream starts, defaults to 0. The start is inclusive,

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Enable or disable accepting ranged requests, defaults to true.
 Disabling this will not send `Accept-Ranges` and ignore the contents
 of the `Range` request header.
 
+##### allowSpecialFiles
+
+When true Serve files in linux based systems ( in folders like /proc ), default is set to false and files return a size=0.
+
 ##### cacheControl
 
 Enable or disable setting `Cache-Control` response header, defaults to
@@ -110,10 +114,6 @@ This can also be a string accepted by the
 ##### root
 
 Serve files relative to `path`.
-
-##### allowSpecialFiles
-
-When true Serve files in linux based systems ( in folders like /proc ), default is set to false and files return a size=0.
 
 ##### start
 

--- a/README.md
+++ b/README.md
@@ -267,6 +267,51 @@ function directory (res, path) {
 }
 ```
 
+### Serving special files (e.g. /proc, dotfiles, hidden files)
+
+By default, files that report a size of 0 — such as Linux virtual files in
+`/proc` or `/sys` — are not streamed because their size cannot be determined
+ahead of time. Setting `allowSpecialFiles: true` opts in to streaming those
+files without a `Content-Length` header.
+
+This is also a useful pattern when your root directory contains dotfiles or
+other hidden files that you want to expose intentionally (combine with
+`dotfiles: 'allow'`).
+
+```js
+var http = require('http')
+var parseUrl = require('parseurl')
+var send = require('send')
+
+// Serve Linux virtual files from /proc (e.g. GET /cpuinfo → /proc/cpuinfo)
+var server = http.createServer(function onRequest (req, res) {
+  send(req, parseUrl(req).pathname, {
+    root: '/proc',
+    allowSpecialFiles: true
+  }).pipe(res)
+})
+
+server.listen(3000)
+```
+
+To also allow dotfiles and other hidden files alongside special files:
+
+```js
+var http = require('http')
+var parseUrl = require('parseurl')
+var send = require('send')
+
+var server = http.createServer(function onRequest (req, res) {
+  send(req, parseUrl(req).pathname, {
+    root: '/www/public',
+    allowSpecialFiles: true,
+    dotfiles: 'allow'
+  }).pipe(res)
+})
+
+server.listen(3000)
+```
+
 ### Serving from a root directory with custom error-handling
 
 ```js

--- a/index.js
+++ b/index.js
@@ -579,6 +579,20 @@ SendStream.prototype.send = function send (path, stat) {
   opts.start = offset
   opts.end = Math.max(offset, offset + len - 1)
 
+  // Special file handling: size=0 but readable
+  const isSpecialFile = stat.size === 0 && this.options.allowSpecialFiles;
+
+  if (isSpecialFile) {
+    // Skip Content-Length, just stream
+    debug('special file streaming without Content-Length');
+    if (req.method === 'HEAD') {
+      res.end();
+      return;
+    }
+    this.stream(path, options); // stream without start/end
+    return;
+  }
+
   // content-length
   res.setHeader('Content-Length', len)
 

--- a/index.js
+++ b/index.js
@@ -103,6 +103,10 @@ function SendStream (req, path, options) {
     ? Boolean(opts.acceptRanges)
     : true
 
+  this._allowSpecialFiles = opts.allowSpecialFiles !== undefined
+    ? Boolean(opts.allowSpecialFiles)
+    : false
+
   this._cacheControl = opts.cacheControl !== undefined
     ? Boolean(opts.cacheControl)
     : true
@@ -580,7 +584,7 @@ SendStream.prototype.send = function send (path, stat) {
   opts.end = Math.max(offset, offset + len - 1)
 
   // Special file handling: size=0 but readable
-  const isSpecialFile = stat.size === 0 && this.options.allowSpecialFiles;
+  const isSpecialFile = stat.size === 0 && this._allowSpecialFiles;
 
   if (isSpecialFile) {
     // Skip Content-Length, just stream

--- a/test/send.js
+++ b/test/send.js
@@ -1279,6 +1279,41 @@ describe('send(file, options)', function () {
       })
     })
 
+    describe('send special files', function () {
+      it('should stream /proc/meminfo when allowSpecialFiles is true', function (done) {
+        var app = http.createServer(function (req, res) {
+          send(req, '/proc/meminfo', { allowSpecialFiles: true }).pipe(res)
+        })
+    
+        request(app)
+          .get('/')
+          .expect(200)
+          .expect('Content-Type', /plain|text/)
+          .end(function (err, res) {
+            if (err) return done(err)
+            // /proc/meminfo should contain "MemTotal"
+            assert.ok(res.text.includes('MemTotal'))
+            done()
+          })
+      })
+
+      it('should return empty when allowSpecialFiles is false', function (done) {
+        var app = http.createServer(function (req, res) {
+          send(req, '/proc/meminfo').pipe(res)
+        })
+    
+        request(app)
+          .get('/')
+          .expect(200)
+          .end(function (err, res) {
+            if (err) return done(err)
+            // Without the flag, Content-Length is 0
+            assert.strictEqual(res.text, '')
+            done()
+          })
+      })
+    })
+
     describe('when missing', function () {
       it('should consider .. malicious', function (done) {
         var app = http.createServer(function (req, res) {


### PR DESCRIPTION
### Add allowSpecialFiles option to support streaming pseudo‑files (e.g. /proc).

**Summary**  
This PR introduces a new opt‑in option, allowSpecialFiles, to the send module. It addresses the issue where attempting to download pseudo‑files (e.g. /proc/meminfo on Linux) results in empty responses because fs.stat reports a size of 0.

**Problem**
- send relies on fs.stat.size to set Content-Length.
- For virtual filesystems like /proc, stat.size = 0, so the response is empty.
- Developers currently have to bypass res.download() and use fs.createReadStream manually.

**Solution**
- Added _allowSpecialFiles flag in SendStream constructor (default: false).
- In SendStream.prototype.send, detect when stat.size === 0 and _allowSpecialFiles is enabled.
- Skip setting Content-Length and stream the file directly.
- Maintains existing behavior unless explicitly enabled.

**Usage Example**
```javascript
app.get('/download', (req, res) => {
  res.download('/proc/meminfo', 'meminfo.txt', { allowSpecialFiles: true }, (err) => {
    if (err) console.error('Download error:', err)
  })
})
```

**Security Considerations**
- By default, allowSpecialFiles is disabled.
- /proc and similar pseudo‑files can expose sensitive system information.
- Developers must consciously enable this option, ensuring safe defaults for all existing applications.

Tests Added

- /proc/meminfo with allowSpecialFiles: true → non‑empty response containing "MemTotal".
- /proc/meminfo without flag → empty response (unchanged behavior).
